### PR TITLE
Add warning notes to both build runners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ branches:
 # Install requirements
 install: pip install -r requirements.txt
 
+# NB: IF YOU CHANGE ANY BUILD OPTIONS, MAKE SURE YOU ALSO CHANGE THEM IN THE MAKEFILE!
+#
 #                   build dir              config dir  nitpick mode on
 #                      v                         v      v
 script: sphinx-build -b html -d build/doctrees -c . -W -n source build/html

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Makefile for Sphinx documentation
 #
 
+# NB: IF YOU CHANGE THE BUILD OPTIONS IN THIS FILE,
+# MAKE SURE YOU ALSO CHANGE THEM IN .travis.yml!
+
 # You can set these variables from the command line.
 SPHINXOPTS    = -c . -j 4
 SPHINXBUILD   = sphinx-build


### PR DESCRIPTION
Our build necessarily must be run by two different runners (travis and
make) because to minimize warnings, we use the "-W" flag, which turns
warnings into errors. For local development, this is disadvantagous
because sphinx-build fails on the first error, but for travis builds,
not setting the flag means code with warnings can be merged/deployed.

Since the builds must be different, they can't both use the same script
to unify options. These comments are intended to mitigate the risk of
the options diverging over time.