### PR TITLE
Remove html suffix from all pages

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -196,7 +196,7 @@ html_show_copyright = True
 #html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+html_file_suffix = ''
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:


### PR DESCRIPTION
My thinking is that this makes it easier to get to pages directly by URL. Implications I could think of:
* cache-bust all users
* possibly negative SEO impact
* possibly break external links

Thoughts?