### PR TITLE
Add wiki links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Sphinx documentation pages are written using a markup language called [reStructu
 
 ## Editing the theme
 
-If you are going to change the theme, you'll need [sass](http://sass-lang.com/ and [grunt](http://gruntjs.com/). If you don't already have [npm](https://www.npmjs.com/package/npm) and [ruby](https://www.ruby-lang.org/en/documentation/installation/) you'll also need to install them.
+If you are going to change the theme, you'll need [sass](http://sass-lang.com/) and [grunt](http://gruntjs.com/). If you don't already have [npm](https://www.npmjs.com/package/npm) and [ruby](https://www.ruby-lang.org/en/documentation/installation/) you'll also need to install them.
 
 Find out if you already have npm and ruby:
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 An SRD and open-source material reference site for 5th edition D&amp;D
 
-## Editing Content
-Open5e is statically generated using [Sphinx](http://www.sphinx-doc.org/en/stable/), a Python-based documentation generator. The content is written in [reStructuredText](http://docutils.sourceforge.net/rst.html).
+## Contributing
 
-If this is your first time working with reST, take a look at the [syntax guide](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html). Also, take a look at our [style guide](https://github.com/eepMoody/open5e/wiki/Style-Guide) and [reST editor tool recommendations](https://github.com/eepMoody/open5e/wiki/reST-Tool-Recommendations).
+Open5e is a community project driven by a small number of voluneers in their spare time. We welcome any and all contributions! If you're working on content, please take a look at our [style guide](https://github.com/eepMoody/open5e/wiki/Style-Guide).
+
+## Editing Content
+Open5e is statically generated using [Sphinx](http://www.sphinx-doc.org/en/stable/), a Python-based documentation generator. The content is written in [reStructuredText](http://docutils.sourceforge.net/rst.html). If this is your first time working with reST, take a look at the [syntax guide](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html). Also, take a look at our [reST editor tool recommendations](https://github.com/eepMoody/open5e/wiki/reST-Tool-Recommendations).
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 An SRD and open-source material reference site for 5th edition D&amp;D
 
 ## Editing Content
+Open5e is statically generated using [Sphinx](http://www.sphinx-doc.org/en/stable/), a Python-based documentation generator. The content is written in [reStructuredText](http://docutils.sourceforge.net/rst.html).
+
+If this is your first time working with reST, take a look at the [syntax guide](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html). Also, take a look at our [style guide](https://github.com/eepMoody/open5e/wiki/Style-Guide) and [reST editor tool recommendations](https://github.com/eepMoody/open5e/wiki/reST-Tool-Recommendations).
 
 ### Installation
-Open5e is statically generated using [Sphinx](http://www.sphinx-doc.org/en/stable/), a Python-based documentation generator.
 
 After cloning the repo, you'll need to install Sphinx. You'll need [Python 2.7](https://www.python.org/downloads/) or higher. We recommend you install Sphinx in a [virtual environment](https://virtualenv.readthedocs.org/en/latest/):
 


### PR DESCRIPTION
Adding wiki references to the readme will drive more views to our style guide and tool recommendations, encouraging higher-quality contributions.

Any ideas on how to draw more attention to the style guide? I feel like it's kinda buried in the middle of the text as-is.