### PR TITLE
Consistency between "*Hit:*" and "*Hit*:"

### DIFF
--- a/source/monsters/miscellaneous-creatures/black-bear.rst
+++ b/source/monsters/miscellaneous-creatures/black-bear.rst
@@ -35,9 +35,9 @@ Actions
 **Multiattack**: The bear makes two attacks: one with its bite and one
 with its claws.
 
-**Bite**: *Melee Weapon Attack:* +3 to hit, reach 5 ft.,
+**Bite**: *Melee Weapon Attack*: +3 to hit, reach 5 ft.,
 one target. *Hit*: 5 (1d6 + 2) piercing damage.
 
 **Claws**: *Melee Weapon
-Attack:* +3 to hit, reach 5 ft., one target. *Hit:* 7 (2d4 + 2) slashing
+Attack*: +3 to hit, reach 5 ft., one target. *Hit*: 7 (2d4 + 2) slashing
 damage.

--- a/source/monsters/monsters_a-z/D/dragons/chromatic/white-dragon-young.rst
+++ b/source/monsters/monsters_a-z/D/dragons/chromatic/white-dragon-young.rst
@@ -41,7 +41,7 @@ Actions
 two with its claws.
 
 **Bite**: *Melee Weapon Attack*: +7 to hit, reach 10
-ft., one target. *Hit:* 15 (2d10 + 4) piercing damage plus 4 (1d8) cold
+ft., one target. *Hit*: 15 (2d10 + 4) piercing damage plus 4 (1d8) cold
 damage.
 
 **Claw**: *Melee Weapon Attack*: +7 to hit, reach 5 ft., one

--- a/source/monsters/monsters_a-z/E/elementals/water-elemental.rst
+++ b/source/monsters/monsters_a-z/E/elementals/water-elemental.rst
@@ -45,7 +45,7 @@ Actions
 **Multiattack**: The elemental makes two slam attacks.
 
 **Slam**: Melee
-*Weapon Attack:* +7 to hit, reach 5 ft., one target. *Hit:* 13 (2d8 + 4)
+*Weapon Attack*: +7 to hit, reach 5 ft., one target. *Hit*: 13 (2d8 + 4)
 bludgeoning damage.
 
 **Whelm (Recharge 4-6)**: Each creature in the

--- a/source/monsters/monsters_a-z/F/fungi/violet-fungus.rst
+++ b/source/monsters/monsters_a-z/F/fungi/violet-fungus.rst
@@ -37,4 +37,4 @@ Actions
 
 **Rotting
 Touch**: *Melee Weapon Attack*: +2 to hit, reach 10 ft., one creature.
-*Hit:* 4 (1d8) necrotic damage.
+*Hit*: 4 (1d8) necrotic damage.

--- a/source/monsters/monsters_a-z/G/gnome-deep-svirfneblin.rst
+++ b/source/monsters/monsters_a-z/G/gnome-deep-svirfneblin.rst
@@ -45,11 +45,11 @@ spells, requiring no material components:
 Actions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**War Pick**: *Melee Weapon Attack:* +4 to hit, reach 5 ft., one target.
-*Hit:* 6 (1d8 + 2) piercing damage.
+**War Pick**: *Melee Weapon Attack*: +4 to hit, reach 5 ft., one target.
+*Hit*: 6 (1d8 + 2) piercing damage.
 
 **Poisoned Dart**: *Ranged Weapon
-Attack:* +4 to hit, range 30/120 ft., one creature. *Hit:* 4 (1d4 + 2)
+Attack*: +4 to hit, range 30/120 ft., one creature. *Hit*: 4 (1d4 + 2)
 piercing damage, and the target must succeed on a DC 12 Constitution
 saving throw or be :ref:`srd:poisoned` for 1 minute. The target can repeat the
 saving throw at the end of each of its turns, ending the effect on

--- a/source/monsters/monsters_a-z/L/lycanthropes/wererat.rst
+++ b/source/monsters/monsters_a-z/L/lycanthropes/wererat.rst
@@ -46,7 +46,7 @@ attacks, only one of which can be a bite.
 
 **Bite (Rat or Hybrid Form
 Only)**: *Melee Weapon Attack*: +4 to hit, reach 5 ft., one target.
-*Hit:* 4 (1d4 + 2) piercing damage. If the target is a humanoid, it must
+*Hit*: 4 (1d4 + 2) piercing damage. If the target is a humanoid, it must
 succeed on a DC 11 Constitution saving throw or be cursed with wererat
 lycanthropy.
 

--- a/source/monsters/monsters_a-z/S/salamander.rst
+++ b/source/monsters/monsters_a-z/S/salamander.rst
@@ -44,7 +44,7 @@ Actions
 and one with its tail.
 
 **Spear**: *Melee or Ranged Weapon Attack*: +7 to
-hit, reach 5 ft. or range 20 ft./60 ft., one target. *Hit:* 11 (2d6 + 4)
+hit, reach 5 ft. or range 20 ft./60 ft., one target. *Hit*: 11 (2d6 + 4)
 piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands
 to make a melee attack, plus 3 (1d6) fire damage.
 

--- a/source/monsters/monsters_a-z/V/vampires/vampire.rst
+++ b/source/monsters/monsters_a-z/V/vampires/vampire.rst
@@ -98,7 +98,7 @@ vampire can grapple the target (escape DC 18).
 **Bite (Bat or Vampire
 Form Only)**: *Melee Weapon Attack*: +9 to hit, reach 5 ft., one willing
 creature, or a creature that is :ref:`srd:grappled` by the vampire, :ref:`srd:incapacitated`,
-or :ref:`srd:restrained`. *Hit:* 7 (1d6 + 4) piercing damage plus 10 (3d6) necrotic
+or :ref:`srd:restrained`. *Hit*: 7 (1d6 + 4) piercing damage plus 10 (3d6) necrotic
 damage. The target's hit point maximum is reduced by an amount equal to
 the necrotic damage taken, and the vampire regains hit points equal to
 that amount. The reduction lasts until the target finishes a long rest.

--- a/source/monsters/statistics.rst
+++ b/source/monsters/statistics.rst
@@ -557,7 +557,7 @@ this reason, both the average damage and the die expression are
 presented.
 
 **Miss.** If an attack has an effect that occurs on a miss, that
-information is presented after the "\ *Miss:*\ " notation.
+information is presented after the "\ *Miss*:\ " notation.
 
 Multiattack
 ^^^^^^^^^^^


### PR DESCRIPTION
Some monsters said "*Hit:*" and some said "*Hit*:" and I kinda prefer the former but there were way more of the latter so I changed the outliers to match the majority.
TL;DR:
It now always says "*Hit*:" and never "*Hit:* and this goes for Miss too.