### PR TITLE
Allow environment variables for SPHINXBUILD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    = -c . -j 4 -n
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD  ?= sphinx-build
 PAPER         =
 BUILDDIR      = build
 


### PR DESCRIPTION
Previously the `SPHINXBUILD` variable had to be set in make, for example

```
make json SPHINXBUILD=$(brew --prefix sphinx-doc)/bin/sphinx-build
```

though the error message the Makefile generates states to set the `SPHINXBUILD` environment variable.
This change doesn't override the `SPHINXBUILD` environment variable if it's present, which means the script now takes the environment variable into account.