### PR TITLE
Misplaced paragraphs

### DIFF
--- a/source/classes/druid.rst
+++ b/source/classes/druid.rst
@@ -139,6 +139,18 @@ do so, choose a number of druid spells equal to your Wisdom modifier +
 your druid level (minimum of one spell). The spells must be of a level
 for which you have spell slots.
 
+For example, if you are a 3rd-level druid, you have four 1st-level
+and two 2nd-level spell slots. With a Wisdom of 16, your list of prepared spells
+can a include six spells of 1st or 2nd level, in any combination. If you
+prepare the 1st-level spell *cure wounds,* you can cast it using a
+1st-level or 2nd-level slot. Casting the spell doesn't remove it from
+your list of prepared spells.
+
+You can also change your list of prepared spells when you finish a long
+rest. Preparing a new list of druid spells requires time spent in prayer
+and meditation: at least 1 minute per spell level for each spell on your
+list.
+
 Spellcasting Focus
 ~~~~~~~~~~~~~~~~~~
 
@@ -186,18 +198,6 @@ Level  CR   Limitations                  Example
 4th    1/2  No flying speed              Crocodile
 8th    1    ---                            Giant eagle
 =====  ===  ===========================  =======
-
-For example, if you are a 3rd-level druid, you have four 1st-level
-and two 2nd-level spell slots. With a Wisdom of 16, your list of prepared spells
-can a include six spells of 1st or 2nd level, in any combination. If you
-prepare the 1st-level spell *cure wounds,* you can cast it using a
-1st-level or 2nd-level slot. Casting the spell doesn't remove it from
-your list of prepared spells.
-
-You can also change your list of prepared spells when you finish a long
-rest. Preparing a new list of druid spells requires time spent in prayer
-and meditation: at least 1 minute per spell level for each spell on your
-list.
 
 You can stay in a beast shape for a number of hours equal to half your
 druid level (rounded down). You then revert to your normal form unless


### PR DESCRIPTION
Paragraphs detailing how to prepare spells were located in the Wild Shape section, rather than under Preparing and Casting Spells.