### PR TITLE
local environment variables

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -13,9 +13,14 @@ To run a single command, use `pipenv run`. To install a python module, use `pipe
 ## Quickstart
 
 ```
+export OPEN_5E_ROOT=`pwd` # at the root level of the cloned project
+export DJANGO_SECRET='@pt#ouh)@!c+2eh(!aj_vtc=s7t$uk-l1!ry3^fcercz%si01@' # this should be a nukable test key that you're manually replacing at startup time for production
+
 cd server
 pipenv install
 pipenv run python manage.py migrate
+pipenv run python manage.py shell < scripts/add_srd_monsters.py
+pipenv run python manage.py shell < scripts/add_srd_spells.py
 pipenv run python manage.py runserver
 ```
 

--- a/server/scripts/add_srd_monsters.py
+++ b/server/scripts/add_srd_monsters.py
@@ -1,5 +1,6 @@
 import os, sys
-sys.path.append('/Users/ean/dev/open5e/server')
+root_path = os.environ['OPEN_5E_ROOT']
+sys.path.append(root_path)
 os.environ['DJANGO_SETTINGS_MODULE'] = 'server.settings'
 import django
 django.setup()
@@ -7,7 +8,9 @@ from django.contrib.auth.models import User
 from api.models import Spell, Monster
 import json
 
-with open('../data/monsters/5e-SRD-Monsters.json') as json_data:
+file_location = root_path + ('' if root_path.endswith('/') else '/') + 'data/monsters/5e-SRD-Monsters.json'
+
+with open(file_location) as json_data:
     monsters = json.load(json_data)
     for mob in monsters:
         m = Monster.objects.create()

--- a/server/scripts/add_srd_spells.py
+++ b/server/scripts/add_srd_spells.py
@@ -1,5 +1,6 @@
 import os, sys
-sys.path.append('/Users/ean/dev/open5e/server')
+root_path = os.environ['OPEN_5E_ROOT']
+sys.path.append(root_path)
 os.environ['DJANGO_SETTINGS_MODULE'] = 'server.settings'
 import django
 django.setup()
@@ -7,7 +8,9 @@ from django.contrib.auth.models import User
 from api.models import Spell, Monster
 import json
 
-with open('../data/spells/5e-SRD-Spells.json') as json_data:
+file_location = root_path + ('' if root_path.endswith('/') else '/') + 'data/spells/5e-SRD-Spells.json'
+
+with open(file_location) as json_data:
     spells = json.load(json_data)
     for spell in spells:
         s = Spell.objects.create()

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '@pt#ouh)@!c+2eh(!aj_vtc=s7t$uk-l1!ry3^fcercz%si01@'
+SECRET_KEY = os.environ['DJANGO_SECRET']
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Hoping to address https://github.com/eepMoody/open5e/issues/240. I was wondering about the `sys.path` setting and whether that was being used for anything else apart from the relative file location (because I'm doing it with an absolute location now, so if that parameter doesn't matter, we can just delete all of that). If its being used for something else, then we'll need to test/edit this more.