### PR TITLE
Spell class array tables

### DIFF
--- a/bin/generate.js
+++ b/bin/generate.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const mkdirp = require('mkdirp');
 var getDirName = require('path').dirname;
 
-var spellClassArrays = require('./spellParser');
+var spellClassArrays = require('./spellClassArrays.js');
 
 
 function cleanName(str) {
@@ -35,9 +35,8 @@ function fileParser(input, name, listName) {
     })
     console.log(`writing individual ${name} files:`);
     for (item in obj) {
-      for (item in obj) {
         if(name === 'spell'){
-         obj[item] = spellParser(obj[item]);
+         obj[item] = spellClassArrays(obj[item]);
        }
       const itemJSON = obj[item];
       const itemName = cleanName(itemJSON.name)

--- a/bin/generate.js
+++ b/bin/generate.js
@@ -7,6 +7,9 @@ const fs = require('fs');
 const mkdirp = require('mkdirp');
 var getDirName = require('path').dirname;
 
+var spellClassArrays = require('./spellParser');
+
+
 function cleanName(str) {
   const cleaned = slugify(str.toLowerCase(), {remove: /[*+~.()"!:@/]/g})
   return cleaned;
@@ -32,6 +35,10 @@ function fileParser(input, name, listName) {
     })
     console.log(`writing individual ${name} files:`);
     for (item in obj) {
+      for (item in obj) {
+        if(name === 'spell'){
+         obj[item] = spellParser(obj[item]);
+       }
       const itemJSON = obj[item];
       const itemName = cleanName(itemJSON.name)
       const filename = `${__dirname}/../static/json/${listName}/${itemName}.json`;

--- a/bin/generate.js
+++ b/bin/generate.js
@@ -58,7 +58,11 @@ function indexJson (files, listName) {
     for (item in json) {
       const thisItem = json[item];
       const slug = slugify(thisItem.name.toLowerCase());
-      list.push({name: thisItem.name, slug: slug})
+      if(listName === 'spell'){
+        list.push({name: thisItem.name, slug: slug, dnd_class: thisItem.class, school: thisItem.school})
+      }else{
+        list.push({name: thisItem.name, slug: slug})
+      }
     }
   }
   writeFile(path, list, function(err){

--- a/bin/spellClassArrays.js
+++ b/bin/spellClassArrays.js
@@ -1,0 +1,16 @@
+module.exports = function spellClassArrays(input){
+    // spells classes and archetypes to arrays
+    if(input.class)
+    input.class = input.class.split(',');
+    if(input.archetype)
+    input.archetype = input.archetype.split(',');
+    if(input.circles)
+    input.circles = input.circles.split(',');
+    if(input.domains)
+    input.domains = input.domains.split(',');
+    if(input.oaths)
+    input.oaths = input.oaths.split(',');
+    if(input.patrons)
+    input.patrons = input.patrons.split(',');
+    return input;
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -10,6 +10,7 @@
       </div>  
       <ul v-show="sections[0] != 'loading'">
         <nuxt-link tag="li" to="/spells/spells-list">Spells</nuxt-link>
+        <nuxt-link tag="li" to="/spells/spell-tables">Spell Table</nuxt-link>
         <nuxt-link tag="li" to="/monsters/monster-list">Monsters</nuxt-link>
         <nuxt-link tag="li" to="/magicitems/magicitem-list">Magic Items</nuxt-link>
         <nuxt-link tag="li" to="/characters/">Characters</nuxt-link>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -10,7 +10,6 @@
       </div>  
       <ul v-show="sections[0] != 'loading'">
         <nuxt-link tag="li" to="/spells/spells-list">Spells</nuxt-link>
-        <nuxt-link tag="li" to="/spells/spell-tables">Spell Table</nuxt-link>
         <nuxt-link tag="li" to="/monsters/monster-list">Monsters</nuxt-link>
         <nuxt-link tag="li" to="/magicitems/magicitem-list">Magic Items</nuxt-link>
         <nuxt-link tag="li" to="/characters/">Characters</nuxt-link>

--- a/pages/spells/_id.vue
+++ b/pages/spells/_id.vue
@@ -2,7 +2,7 @@
   <section class="container docs-container">
     <div>
       <h1>{{spell.name}}</h1>
-      <p><em>{{spell.level}} {{spell.school}}</em> | ({{spell.class}})</p>
+      <p><em>{{spell.level}} {{spell.school}}</em> | ({{classList}})</p>
       <p><label>Range:</label> {{spell.range}}</p>
       <p><label>Casting Time:</label> {{spell.casting_time}} <span v-if="spell.ritual === 'yes'">{{spell.ritual}} (Ritual)</span></p>
       <p><label>Components: {{spell.components}} <span v-if="spell.material">({{spell.material}})</span></label></p>
@@ -25,6 +25,7 @@ export default {
     return axios.get(`/json/spells/${this.$route.params.id}.json`) //you will need to enable CORS to make this work
     .then(response => {
       this.spell = response.data
+      this.classList = response.data.class.join(',')
     })
   },
   data () {

--- a/pages/spells/_id.vue
+++ b/pages/spells/_id.vue
@@ -31,6 +31,7 @@ export default {
   data () {
     return {
       spell: [],
+      classList: []
     }
   },
   computed: {

--- a/pages/spells/spell-tables.vue
+++ b/pages/spells/spell-tables.vue
@@ -1,0 +1,97 @@
+<template>
+  <section class="container">
+    <h2 class="filter-header">
+      Spell Table HERE
+      <filter-input v-on:input="updateFilter" placeholder="Filter spells..."></filter-input>
+    </h2>     
+    <div>
+        <table>
+    <thead>
+      <tr>
+        <th v-on:click="sort('name')">Name</th>
+        <th v-on:click="sort('school')">School</th>
+        <th v-on:click="sort('level')">Level</th>
+        <th v-on:click="sort('components')">Components</th>
+        <th v-on:click="sort('concentration')">Concentration</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="spell in spellsListed" :key="spell.name">
+        <td>{{spell.name}}</td>
+        <td>{{spell.school}}</td>
+        <td>{{spell.level}}</td>
+        <td>{{spell.components}}</td>
+        <td>{{spell.concentration}}</td>
+      </tr>
+    </tbody>
+  </table>
+    </div>
+  </section>
+</template>
+
+<script>
+import axios from 'axios'
+import FilterInput from '~/components/FilterInput.vue'
+
+export default {
+  components: {
+    FilterInput
+  },
+  mounted () {
+    return axios.get(`${process.env.apiUrl}/spells/?fields=slug,name,dnd_class,school,level,concentration,components&limit=1000`) //you will need to enable CORS to make this work
+    .then(response => {
+      this.spells = response.data.results
+    })
+  },
+  data () {
+    return {
+      spells: [],
+      filter: '', 
+      currentSortProperty:'name',
+      currentSortDir:'asc'
+    }
+  },
+  methods: {
+    updateFilter: function(val) {
+      this.filter = val;
+    },
+    spellListLength: function() { 
+      return Object.keys(this.spellsListed).length; 
+    },
+    sort:function(prop) {
+        if(prop === this.currentSortProperty) {
+        this.currentSortPropertyDir = this.currentSortDir==='asc'?'desc':'asc';
+        }
+        this.currentSortProperty = prop;
+        this.spellsListed = {};
+    }
+  },
+  computed: {
+    // a computed getter
+    spellsListed:{
+       get: function(){    
+          return this.filteredSpells
+        },
+        set: function () {
+            return this.filteredSpells.sort((a,b) => {
+            let modifier = 1;
+            if(this.currentSortDir === 'desc') modifier = -1;
+                if(a[this.currentSortProperty] < b[this.currentSortProperty]) return -1 * modifier;
+                if(a[this.currentSortProperty] > b[this.currentSortProperty]) return 1 * modifier;
+                return 0;
+            });
+        }
+    },
+    filteredSpells: function() { 
+      return this.spells.filter(spell => { 
+         return spell.name.toLowerCase().indexOf(this.filter.toLowerCase()) > -1 
+      }) 
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+</style>
+

--- a/pages/spells/spell-tables.vue
+++ b/pages/spells/spell-tables.vue
@@ -10,25 +10,28 @@
         <table>
     <thead>
       <tr>
-        <th v-on:click="sort('name')">Name</th>
-        <th v-on:click="sort('school')">School</th>
-        <th v-on:click="sort('level')">Level</th>
-        <th v-on:click="sort('components')">Components</th>
-        <th v-on:click="sort('concentration')">Concentration</th>
+        <th class="spell-table-header" v-on:click="sort('name')">Name</th>
+        <th class="spell-table-header" v-on:click="sort('school')">School</th>
+        <th class="spell-table-header" v-on:click="sort('level')">Level</th>
+        <th class="spell-table-header" v-on:click="sort('components')">Component</th>
+        <th class="spell-table-header-class">Class</th>
       </tr>
     </thead>
     <tbody>
       <tr v-for="spell in spellsListed" :key="spell.name">
-        <td>{{spell.name}}</td>
+        <td>   <nuxt-link tag="a" 
+            :params="{id: spell.slug}" 
+            :to="`/spells/${spell.slug}`">{{spell.name}}</nuxt-link>
+        </td>
         <td>{{spell.school}}</td>
         <td>{{spell.level}}</td>
         <td>{{spell.components}}</td>
-        <td>{{spell.concentration}}</td>
+        <td><span v-for="(spellclass, index) in spell.dnd_class" :key="spellclass"><span class="dnd_class" v-on:click="filterByClass(spellclass)">{{spellclass}}</span><span v-if="index+1 < spell.dnd_class.length">, </span></span></td>
       </tr>
     </tbody>
   </table>
     </div>
-   <span style="display:none;"> sort={{currentSortProperty}}, dir={{currentSortDir}}</span>
+   <span style="display:none;">Sorting by sort={{currentSortProperty}}, dir={{currentSortDir}}</span>
   </section>
 </template>
 
@@ -44,6 +47,14 @@ export default {
     return axios.get(`${process.env.apiUrl}/spells/?fields=slug,name,dnd_class,school,level,concentration,components&limit=1000`) //you will need to enable CORS to make this work
     .then(response => {
       this.spells = response.data.results
+      // Until api sends arrays this will work to sort spells by class.
+      this.spells.map((item)=>{
+          item.dnd_class = item.dnd_class.split(",");
+          for(var i = 0; i < item.dnd_class.length; i++){
+              item.dnd_class[i].trim();
+          }
+      })
+    //
     })
   },
   data () {
@@ -51,7 +62,8 @@ export default {
       spells: [],
       filter: '', 
       currentSortProperty:'name',
-      currentSortDir:'asc'
+      currentSortDir:'asc',
+      sortByClass: null
     }
   },
   methods: {
@@ -63,9 +75,15 @@ export default {
     },
     sort:function(prop) {
         if(prop === this.currentSortProperty) {
-        this.currentSortPropertyDir = this.currentSortDir==='asc'?'desc':'asc';
+           this.currentSortDir = this.currentSortDir === 'asc'?'desc':'asc';
         }
         this.currentSortProperty = prop;
+        this.sortByClass = null;
+        this.spellsListed = {};
+    },
+    filterByClass : function(some_class){
+        this.sortByClass = some_class.trim();
+        console.log('filtering by... ' + this.sortByClass)
         this.spellsListed = {};
     }
   },
@@ -95,6 +113,14 @@ export default {
 </script>
 
 <style scoped>
+    .spell-table-header{
+        text-decoration: underline;
+        cursor: pointer;
+        vertical-align: baseline;
+    }
 
+    .spell-table-header-class{
+        vertical-align: baseline;
+    }
 </style>
 

--- a/pages/spells/spell-tables.vue
+++ b/pages/spells/spell-tables.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="container">
     <h2 class="filter-header">
-      Spell Table HERE
+      Spell Table View
       <!-- <button style="text-decoration:underline;" v-on:click="getSpellsByProperty('letter')">Alphabetical</button>
       <button style="text-decoration:underline;" v-on:click="getSpellsByProperty('dnd_class')">Class</button> -->
       <filter-input v-on:input="updateFilter" placeholder="Filter spells..."></filter-input>
@@ -62,8 +62,7 @@ export default {
       spells: [],
       filter: '', 
       currentSortProperty:'name',
-      currentSortDir:'asc',
-      sortByClass: null
+      currentSortDir:'asc'
     }
   },
   methods: {
@@ -78,12 +77,6 @@ export default {
            this.currentSortDir = this.currentSortDir === 'asc'?'desc':'asc';
         }
         this.currentSortProperty = prop;
-        this.sortByClass = null;
-        this.spellsListed = {};
-    },
-    filterByClass : function(some_class){
-        this.sortByClass = some_class.trim();
-        console.log('filtering by... ' + this.sortByClass)
         this.spellsListed = {};
     }
   },

--- a/pages/spells/spell-tables.vue
+++ b/pages/spells/spell-tables.vue
@@ -2,6 +2,8 @@
   <section class="container">
     <h2 class="filter-header">
       Spell Table HERE
+      <!-- <button style="text-decoration:underline;" v-on:click="getSpellsByProperty('letter')">Alphabetical</button>
+      <button style="text-decoration:underline;" v-on:click="getSpellsByProperty('dnd_class')">Class</button> -->
       <filter-input v-on:input="updateFilter" placeholder="Filter spells..."></filter-input>
     </h2>     
     <div>
@@ -26,6 +28,7 @@
     </tbody>
   </table>
     </div>
+   <span style="display:none;"> sort={{currentSortProperty}}, dir={{currentSortDir}}</span>
   </section>
 </template>
 

--- a/pages/spells/spells-list.vue
+++ b/pages/spells/spells-list.vue
@@ -4,6 +4,7 @@
       Spell List 
       <filter-input v-on:input="updateFilter" placeholder="Filter spells..."></filter-input>
     </h2>     
+    <nuxt-link tag="a" class="table-link" to="/spells/spell-tables">(View As Table)</nuxt-link>
     <div :class="{'three-column': !filter}">
     <p v-if="!spellListLength" >No results</p> 
       <ul class="list--items" 
@@ -78,4 +79,8 @@ export default {
 </script>
 
 <style scoped>
+.table-link{
+  font-size: 0.5em;
+  text-decoration: underline;
+}
 </style>

--- a/pages/spells/spells-list.vue
+++ b/pages/spells/spells-list.vue
@@ -2,12 +2,10 @@
   <section class="container">
     <h2 class="filter-header">
       Spell List 
-      <button style="text-decoration:underline;" v-on:click="getSpellsByProperty('letter')">Alphabetical</button>
-      <button style="text-decoration:underline;" v-on:click="getSpellsByProperty('dnd_class')">Class</button>
       <filter-input v-on:input="updateFilter" placeholder="Filter spells..."></filter-input>
     </h2>     
-    <!--  <div :class="{'three-column': !filter}" v-if="spellsArrangedByProperty === 'letter'">
-   <p v-if="!spellListLength" >No results</p> 
+    <div :class="{'three-column': !filter}">
+    <p v-if="!spellListLength" >No results</p> 
       <ul class="list--items" 
         v-bind:key="letter[0].name.charAt(0)" 
         v-for="(letter, key) in spellsByLetter">
@@ -21,38 +19,19 @@
             </nuxt-link>
           </li>
       </ul>
-    </div> -->
-
-    <div :class="{'three-column': !filter}" v-if="spellsArrangedByProperty">
-    <p v-if="!spellListLength" >No results</p> 
-      <ul class="list--items" 
-        v-bind:key="letter.name" 
-        v-for="(letter, key) in spellsListed">
-
-        <h3 v-if="!filter">{{key}}</h3>
-          <li v-bind:key="spell.name" v-for="spell in letter">
-            <nuxt-link tag="a" 
-            :params="{id: spell.slug}" 
-            :to="`/spells/${spell.slug}`">
-              {{spell.name}}
-            </nuxt-link>
-          </li>
-      </ul>
     </div>
-
   </section>
 </template>
 
 <script>
 import axios from 'axios'
 import FilterInput from '~/components/FilterInput.vue'
-
 export default {
   components: {
     FilterInput
   },
   mounted () {
-    return axios.get(`${process.env.apiUrl}/spells/?fields=slug,name,dnd_class,school&limit=1000`) //you will need to enable CORS to make this work
+    return axios.get(`${process.env.apiUrl}/spells/?fields=slug,name&limit=1000`) //you will need to enable CORS to make this work
     .then(response => {
       this.spells = response.data.results
     })
@@ -61,65 +40,25 @@ export default {
     return {
       spells: [],
       filter: '', 
-      spellsArrangedByProperty: 'letter'
     }
   },
   methods: {
     updateFilter: function(val) {
       this.filter = val;
-    },
-    getSpellsByProperty: function(property){
-      console.log(property);
-      if(property === 'letter'){
-        let letters = {};
-        for (let i = 0; i < this.filteredSpells.length; i++){ 
-          let firstLetter = this.filteredSpells[i].name.charAt(0).toLowerCase(); 
-          if (!(firstLetter in letters)) {
-            letters[firstLetter] = [];
-          }
-          letters[firstLetter].push(this.filteredSpells[i]); 
-        }
-        this.spellsListed = letters;
-        this.spellsArrangedByProperty= 'letters';
-      }
-      if(property === 'dnd_class'){
-        let classes = {};
-        for (let i = 0; i < this.filteredSpells.length; i++){
-          this.filteredSpells[i].dnd_class.split(',').reduce((acc, single_class) => {
-            var className = single_class.trim()
-            if(!classes[className]){
-              classes[className] = [];
-            }
-            classes[className].push(this.filteredSpells[i]);
-          },{})
-        }
-        console.log(classes);
-         this.spellsListed = classes;
-         this.spellsArrangedByProperty= 'dnd_class';
-      }
-    }, 
-    spellListLength: function() { 
-      return Object.keys(this.spellsListed).length; 
-    } 
+    }
   },
   computed: {
     // a computed getter
-    spellsListed:{
-       get: function(){
-       let letters = {};
-       for (let i = 0; i < this.filteredSpells.length; i++){ 
-              let firstLetter = this.filteredSpells[i].name.charAt(0).toLowerCase(); 
-              if (!(firstLetter in letters)) {
-                letters[firstLetter] = [];
-              }
-              letters[firstLetter].push(this.filteredSpells[i]); 
-            }
-          return letters;
-         },
-      set: function (newValue) {
-        alert('setter!!!' + newValue[0]);
-        return newValue
+    spellsByLetter: function () {
+      let letters = {};
+      for (let i = 0; i < this.filteredSpells.length; i++){ 
+        let firstLetter = this.filteredSpells[i].name.charAt(0).toLowerCase(); 
+        if (!(firstLetter in letters)) {
+          letters[firstLetter] = [];
+        }
+        letters[firstLetter].push(this.filteredSpells[i]); 
       }
+      return letters
     },
     filteredSpells: function() { 
       return this.spells.filter(spell => { 
@@ -130,12 +69,13 @@ export default {
       return { 
         'three-column': !this.filter, 
       } 
-    }
+    }, 
+    spellListLength: function() { 
+      return Object.keys(this.spellsByLetter).length; 
+    } 
   }
 }
 </script>
 
 <style scoped>
-
 </style>
-

--- a/pages/spells/spells-list.vue
+++ b/pages/spells/spells-list.vue
@@ -2,10 +2,12 @@
   <section class="container">
     <h2 class="filter-header">
       Spell List 
+      <button style="text-decoration:underline;" v-on:click="getSpellsByProperty('letter')">Alphabetical</button>
+      <button style="text-decoration:underline;" v-on:click="getSpellsByProperty('dnd_class')">Class</button>
       <filter-input v-on:input="updateFilter" placeholder="Filter spells..."></filter-input>
     </h2>     
-    <div :class="{'three-column': !filter}">
-    <p v-if="!spellListLength" >No results</p> 
+    <!--  <div :class="{'three-column': !filter}" v-if="spellsArrangedByProperty === 'letter'">
+   <p v-if="!spellListLength" >No results</p> 
       <ul class="list--items" 
         v-bind:key="letter[0].name.charAt(0)" 
         v-for="(letter, key) in spellsByLetter">
@@ -19,7 +21,25 @@
             </nuxt-link>
           </li>
       </ul>
+    </div> -->
+
+    <div :class="{'three-column': !filter}" v-if="spellsArrangedByProperty">
+    <p v-if="!spellListLength" >No results</p> 
+      <ul class="list--items" 
+        v-bind:key="letter.name" 
+        v-for="(letter, key) in spellsListed">
+
+        <h3 v-if="!filter">{{key}}</h3>
+          <li v-bind:key="spell.name" v-for="spell in letter">
+            <nuxt-link tag="a" 
+            :params="{id: spell.slug}" 
+            :to="`/spells/${spell.slug}`">
+              {{spell.name}}
+            </nuxt-link>
+          </li>
+      </ul>
     </div>
+
   </section>
 </template>
 
@@ -32,7 +52,7 @@ export default {
     FilterInput
   },
   mounted () {
-    return axios.get(`${process.env.apiUrl}/spells/?fields=slug,name&limit=1000`) //you will need to enable CORS to make this work
+    return axios.get(`${process.env.apiUrl}/spells/?fields=slug,name,dnd_class,school&limit=1000`) //you will need to enable CORS to make this work
     .then(response => {
       this.spells = response.data.results
     })
@@ -41,25 +61,65 @@ export default {
     return {
       spells: [],
       filter: '', 
+      spellsArrangedByProperty: 'letter'
     }
   },
   methods: {
     updateFilter: function(val) {
       this.filter = val;
-    }
+    },
+    getSpellsByProperty: function(property){
+      console.log(property);
+      if(property === 'letter'){
+        let letters = {};
+        for (let i = 0; i < this.filteredSpells.length; i++){ 
+          let firstLetter = this.filteredSpells[i].name.charAt(0).toLowerCase(); 
+          if (!(firstLetter in letters)) {
+            letters[firstLetter] = [];
+          }
+          letters[firstLetter].push(this.filteredSpells[i]); 
+        }
+        this.spellsListed = letters;
+        this.spellsArrangedByProperty= 'letters';
+      }
+      if(property === 'dnd_class'){
+        let classes = {};
+        for (let i = 0; i < this.filteredSpells.length; i++){
+          this.filteredSpells[i].dnd_class.split(',').reduce((acc, single_class) => {
+            var className = single_class.trim()
+            if(!classes[className]){
+              classes[className] = [];
+            }
+            classes[className].push(this.filteredSpells[i]);
+          },{})
+        }
+        console.log(classes);
+         this.spellsListed = classes;
+         this.spellsArrangedByProperty= 'dnd_class';
+      }
+    }, 
+    spellListLength: function() { 
+      return Object.keys(this.spellsListed).length; 
+    } 
   },
   computed: {
     // a computed getter
-    spellsByLetter: function () {
-      let letters = {};
-      for (let i = 0; i < this.filteredSpells.length; i++){ 
-        let firstLetter = this.filteredSpells[i].name.charAt(0).toLowerCase(); 
-        if (!(firstLetter in letters)) {
-          letters[firstLetter] = [];
-        }
-        letters[firstLetter].push(this.filteredSpells[i]); 
+    spellsListed:{
+       get: function(){
+       let letters = {};
+       for (let i = 0; i < this.filteredSpells.length; i++){ 
+              let firstLetter = this.filteredSpells[i].name.charAt(0).toLowerCase(); 
+              if (!(firstLetter in letters)) {
+                letters[firstLetter] = [];
+              }
+              letters[firstLetter].push(this.filteredSpells[i]); 
+            }
+          return letters;
+         },
+      set: function (newValue) {
+        alert('setter!!!' + newValue[0]);
+        return newValue
       }
-      return letters
     },
     filteredSpells: function() { 
       return this.spells.filter(spell => { 
@@ -70,10 +130,7 @@ export default {
       return { 
         'three-column': !this.filter, 
       } 
-    }, 
-    spellListLength: function() { 
-      return Object.keys(this.spellsByLetter).length; 
-    } 
+    }
   }
 }
 </script>


### PR DESCRIPTION
As suggested by your issue here:

https://github.com/eepMoody/open5e/issues/264

A table view for spells, that can be sorted/filtered/viewed by other properties than name alphabetically.

It will make sense to add sorting by class after https://github.com/eepMoody/open5e/issues/235 is changed to give spell classes as arrays from the API