### PR TITLE
Add fallback for initiative

### DIFF
--- a/composables/monsters.ts
+++ b/composables/monsters.ts
@@ -28,6 +28,11 @@ export const useMonster = (slug: string) => {
         modifier: useFormatModifier(monster[ability], { inputType: 'score' }),
         save: monster[`${ability}_save`],
       }));
+
+      // Add synthetic initiative bonus property
+      monster.initiative_bonus =
+        monster.initiative_bonus ?? monster.modifiers?.dexterity;
+
       return monster as Record<string, string>;
     },
   });

--- a/composables/monsters.ts
+++ b/composables/monsters.ts
@@ -28,11 +28,6 @@ export const useMonster = (slug: string) => {
         modifier: useFormatModifier(monster[ability], { inputType: 'score' }),
         save: monster[`${ability}_save`],
       }));
-
-      // Add synthetic initiative bonus property
-      monster.initiative_bonus =
-        monster.initiative_bonus ?? monster.modifiers?.dexterity;
-
       return monster as Record<string, string>;
     },
   });

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -60,9 +60,9 @@
       <dt class="font-bold after:content-['_']">Initiative Bonus</dt>
       <dd
         class="w-min cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
-        @click="useDiceRoller(initiative)"
+        @click="useDiceRoller(monster.initiative_bonus)"
       >
-        {{ initiative }}
+        {{ monster.initiative_bonus }}
       </dd>
 
       <!-- HIT POINTS -->
@@ -254,11 +254,7 @@ const params = {
   languages__fields: 'name',
   document__fields: 'name,key,permalink',
 };
-const { data: monster } = useFindOne(
-  API_ENDPOINTS.monsters,
-  useRoute().params.id,
-  { params }
-);
+const { data: monster } = useMonster(useRoute().params.id);
 
 // Sort monster actions by type (ie. 'action', 'bonus action', 'reaction').
 // rtrns an object whose keys are action types & vals are arrays of actions.
@@ -282,11 +278,6 @@ const snakeToTitleCase = (input) =>
     .split('_')
     .map((word) => word[0].toUpperCase() + word.substring(1))
     .join(' ');
-
-const initiative = computed(() => {
-  if (monster.value?.initiative_bonus) return monster.value.initiative_bonus;
-  else return monster.value?.modifiers?.dexterity;
-});
 
 // Format monster speeds for template
 const speeds = computed(() => {

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -266,7 +266,7 @@ const initiativeBonus = computed(() => {
   return monster.value.initiative_bonus ?? monster.value.modifiers?.dexterity;
 });
 
-// Sort monster actions by type (ie. 'action', 'bonus action', 'reaction').
+// Sort monster actions by type (ie. 'action', 'bonus action', 'reaction'). 
 // rtrns an object whose keys are action types & vals are arrays of actions.
 const actions = computed(() => {
   if (!monster?.value?.actions) return {};

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -60,11 +60,9 @@
       <dt class="font-bold after:content-['_']">Initiative Bonus</dt>
       <dd
         class="w-min cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
-        @click="useDiceRoller(monster.initiative_bonus)"
+        @click="useDiceRoller(initiative)"
       >
-        {{
-          (monster.initiative_bonus > 0 ? '+' : '') + monster.initiative_bonus
-        }}
+        {{ initiative }}
       </dd>
 
       <!-- HIT POINTS -->
@@ -284,6 +282,11 @@ const snakeToTitleCase = (input) =>
     .split('_')
     .map((word) => word[0].toUpperCase() + word.substring(1))
     .join(' ');
+
+const initiative = computed(() => {
+  if (monster.value?.initiative_bonus) return monster.value.initiative_bonus;
+  else return monster.value?.modifiers?.dexterity;
+});
 
 // Format monster speeds for template
 const speeds = computed(() => {

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -60,9 +60,9 @@
       <dt class="font-bold after:content-['_']">Initiative Bonus</dt>
       <dd
         class="w-min cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
-        @click="useDiceRoller(monster.initiative_bonus)"
+        @click="useDiceRoller(initiativeBonus)"
       >
-        {{ monster.initiative_bonus }}
+        {{ initiativeBonus }}
       </dd>
 
       <!-- HIT POINTS -->
@@ -254,7 +254,17 @@ const params = {
   languages__fields: 'name',
   document__fields: 'name,key,permalink',
 };
-const { data: monster } = useMonster(useRoute().params.id);
+const { data: monster } = useFindOne(
+  API_ENDPOINTS.monsters,
+  useRoute().params.id,
+  { params }
+);
+
+// Calculate initiative bonus from dexterity modifier if not explicitly set
+const initiativeBonus = computed(() => {
+  if (!monster.value) return 0;
+  return monster.value.initiative_bonus ?? monster.value.modifiers?.dexterity;
+});
 
 // Sort monster actions by type (ie. 'action', 'bonus action', 'reaction').
 // rtrns an object whose keys are action types & vals are arrays of actions.

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -62,7 +62,7 @@
         class="w-min cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
         @click="useDiceRoller(initiativeBonus)"
       >
-        {{ initiativeBonus }}
+        {{ useFormatModifier(initiativeBonus) }}
       </dd>
 
       <!-- HIT POINTS -->
@@ -260,13 +260,13 @@ const { data: monster } = useFindOne(
   { params }
 );
 
-// Calculate initiative bonus from dexterity modifier if not explicitly set 
+// Calculate initiative bonus from dexterity modifier if not explicitly set
 const initiativeBonus = computed(() => {
   if (!monster.value) return 0;
   return monster.value.initiative_bonus ?? monster.value.modifiers?.dexterity;
 });
 
-// Sort monster actions by type (ie. 'action', 'bonus action', 'reaction'). 
+// Sort monster actions by type (ie. 'action', 'bonus action', 'reaction').
 // rtrns an object whose keys are action types & vals are arrays of actions.
 const actions = computed(() => {
   if (!monster?.value?.actions) return {};

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -115,7 +115,7 @@
         </li>
       </ul>
 
-      <!-- RESISTANCES, VULNERABILITY, AND IMMUNITIES -->
+      <!-- RESISTANCES, VULNERABILITY AND IMMUNITIES -->
       <ul v-for="(data, title) in resistancesAndVulnerabilities" :key="title">
         <label class="inline font-bold after:content-['_']">{{ title }}</label>
         <li

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -260,7 +260,7 @@ const { data: monster } = useFindOne(
   { params }
 );
 
-// Calculate initiative bonus from dexterity modifier if not explicitly set
+// Calculate initiative bonus from dexterity modifier if not explicitly set 
 const initiativeBonus = computed(() => {
   if (!monster.value) return 0;
   return monster.value.initiative_bonus ?? monster.value.modifiers?.dexterity;


### PR DESCRIPTION
Added a fallback to dexterity, for monsters that don't have an initative_bonus already. This doesn't overwrite the incoming value if it exists, so it should be forward-compatible when we add calculated values to the API.

Currently most monsters on staging come back undefined for this:
<img width="461" alt="image" src="https://github.com/user-attachments/assets/92c79434-011e-4752-8460-f2dc1efcd935" />

With the fallback, they now fall back to dexterity bonus. 
<img width="659" alt="image" src="https://github.com/user-attachments/assets/ffaaa3b6-d3b2-4f1b-8e89-4385c57ee1e2" />