### PR TITLE
Sort actions on `"/monsters/[id]"` page

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -266,7 +266,7 @@ const { data: monster } = useFindOne(
 // rtrns an object whose keys are action types & vals are arrays of actions.
 const actions = computed(() => {
   if (!monster?.value?.actions) return {};
-  return monster.value.actions.reduce(
+  const actionsByType = monster.value.actions.reduce(
     (output, action) => {
       const { action_type: actionType } = action;
       if (output[actionType]) output[actionType].push(action);
@@ -275,6 +275,13 @@ const actions = computed(() => {
     },
     { ACTION: [] }
   );
+
+  // sort monster actions according to the value of their 'order' field
+  Object.keys(actionsByType).forEach((type) => {
+    actionsByType[type].sort((a, b) => a['order'] - b['order']);
+  });
+
+  return actionsByType;
 });
 
 // Converts SNAKE_CASE to Title Case, used for action type headers


### PR DESCRIPTION
## Description
This PR fixes an issue on the front-end where creature actions were displayed alphabetically instead of by their order they appear in their original source statblocks. This fixes numerous issues on the `/monsters/[id]` page where the order of the action lists really didn't make any sense and made finding them more difficult to parse (ie. multiattack infromation appearing after the attacks it references.

This change was made possible https://github.com/open5e/open5e-api/pull/668 on the API.

## Related Issue
Closes #683 

## How was this tested
First, the code was visually AB tested against the `staging` branch to make sure the creature items were being ordered in the first place. Then several monsters in the WOTC and A5E SRDs were compared to their source blocks to make sure that the order of the actions was correct.

Finally, tests and build processes were run to make sure there were no unintentially app-breaking side-effects