### PR TITLE
Added armor detail to single-view Monster page

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -48,11 +48,8 @@
       <dt class="font-bold after:content-['_']">Armor Class</dt>
       <dd>
         <span>{{ monster.armor_class }}</span>
-        <span
-          v-if="monster.armor_desc"
-          class="before:content-['_('] after:content-[')']"
-        >
-          {{ monster.armor_desc }}
+        <span v-if="monster.armor_detail" class="text-charcoal dark:text-smoke">
+          ({{ monster.armor_detail }})
         </span>
       </dd>
 


### PR DESCRIPTION
## Description

This PR extends the `/monsters/[id]` page so that an the `"armor_detail"` field returned by the API (recently added in PR https://github.com/open5e/open5e-api/pull/662) is displayed next to a creature's armor class.

The function of the `"armor_detail"` field is to capture the information in parentheses that sometimes follows a monster's armor class which provide contextual information about a creature's armor class. For example, the WOTC SRD Adul Black Dragon has an armor class of `19` and an armor detail of `"natural armor"`. On the fornt-end this is rendered as `"19 (natural armor)"`

## Related Issue
Closes #686

## How was this tested?

This change was principally tested by A/B testing against the `staging` branch and visually confirming that things looked as intended.

Repository tests and build processes were run to confirm that this change had no unintended side-effects. All processes completed without error

