### PR TITLE
Added comma digit-seperate to XP on `/monster/[id]/ page

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -158,11 +158,8 @@
         <span for="challenge" class="inline font-bold after:content-['_']">
           Challenge
         </span>
-        <span>
-          {{
-            `${monster.challenge_rating_text} (${monster.experience_points} XP)`
-          }}
-        </span>
+        <span>{{ monster.challenge_rating_text + ' ' }}</span>
+        <span>{{ `(${monster.experience_points.toLocaleString()} XP)` }}</span>
       </ul>
     </section>
 


### PR DESCRIPTION
## Description

This PR fixes a small visual bug on the `/monsters/[id]` route where a monster's XP didn't include a comma seperator between the thousands and hundreds bits (standard style for all 5e statblocks). This comma was added in by envoking the `.toLocalString()` string method.

<img width="1180" alt="Screenshot 2025-04-21 at 10 19 42" src="https://github.com/user-attachments/assets/fb91805f-9527-434b-a2c0-bfc7202fec5f" />

## Related Issue

Closes #665

## How was this tested?

- A/B tested against the `staging` branch on the Nuxt development server (pointing to a Django test server run the `staging` branch). The website was inspected visually to make sure things were working as we they were intended.
- `npm run test` was run to make sure that all tests were still passing (they were)
- `npm run build` was run to make sure that there were no unintentional build-breaking bugs introduced (there weren't, the build process succeeded without error)

