### PR TITLE
Fixed TypeErrors on `classes/[id]`

### DIFF
--- a/components/ClassTable.vue
+++ b/components/ClassTable.vue
@@ -122,8 +122,8 @@ const props = defineProps({
 
 // Parse proficiency bonuses
 const proficiencies = computed(() => {
-  if (!props?.proficiencyBonus?.table_data.length > 0) return;
-  const { table_data: data } = props.proficiencyBonus;
+  if (!props?.proficiencyBonus?.data_for_class_table.length > 0) return;
+  const { data_for_class_table: data } = props.proficiencyBonus;
   return data.reduce((output, tableRow) => {
     output[tableRow.level] = tableRow.column_value;
     return output;
@@ -140,7 +140,7 @@ const additionalColumnHeaders = computed(() => {
 // columnTitle -> level -> value
 const classResourceTableData = computed(() => {
   return props.classResourceTableColumns.reduce((acc, column) => {
-    const { name: colName, table_data: valuePerLevel } = column;
+    const { name: colName, data_for_class_table: valuePerLevel } = column;
     if (!acc[colName]) acc[colName] = {};
     valuePerLevel.forEach(({ level, column_value: value }) => {
       acc[colName][level] = value;
@@ -160,7 +160,7 @@ const spellslotColumnHeaders = computed(() => {
 const spellSlotTableData = computed(() => {
   const data = props.spellSlots;
   return data.reduce((acc, feature) => {
-    const { name: spellLevel, table_data: slotsPerCharLevel } = feature;
+    const { name: spellLevel, data_for_class_table: slotsPerCharLevel } = feature;
     slotsPerCharLevel.forEach((item) => {
       const { level: classLevel, column_value: spellSlots } = item;
       if (!acc[classLevel]) acc[classLevel] = {};

--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -91,7 +91,7 @@ const classSubroutes = computed(() => {
   if (crumbs.value.length >= 2) {
     const baseClass = crumbs.value[1];
     const subClassesForClass = subClasses
-      .filter(item => item?.['subclass_of']?.includes(baseClass.src))
+      .filter(item => item?.['subclass_of']?.key === baseClass.src)
       .map((item) => {
         const url = `/classes/${baseClass.src}/${item.key}`;
         return { title: item.name, url };

--- a/pages/classes/[className]/index.vue
+++ b/pages/classes/[className]/index.vue
@@ -85,7 +85,7 @@
           <h3>{{ feature.name }}</h3>
           <md-viewer
             :text="feature.desc"
-            header-level="3"
+            :header-level="3"
           />
         </li>
       </ul>
@@ -126,7 +126,7 @@ const features = computed(() => {
       const { feature_type: type } = feature;
       if (type === 'PROFICIENCY_BONUS') acc.proficiencyBonuses = feature;
       else if (type === 'SPELL_SLOTS') acc.spellSlots.push(feature);
-      else if (feature.table_data.length > 0)
+      else if (feature.data_for_class_table.length > 0)
         acc.classTableColumnData.push(feature);
       else if (type === 'CLASS_FEATURE') acc.classFeatures.push(feature);
       else if (type === 'PROFICIENCIES') acc.proficiencies.push(feature);


### PR DESCRIPTION
## Description

This PR fixes a number of bugs that were introduced to the Open5e Website when the `/v2/classes` endpoint was recently updated. The only changes that were made in this PR were to object keys on the page itself, and a handful of components that took data from the same endpoint as props.

The bugs are fixed, and the page works as it did previously.

## Related Issue

Closes #695 

## How was this tested?

The changes were A/B tested against the `staging` branch, both visually and via the browser console. The `test` and `build` commands were also run to make sure that there were no unintended consequences of making these changes (all passed without a hitch)


## Build Preview

[Click here to preview PR](https://deploy-preview-696--open5e-preview.netlify.app/)
