### PR TITLE
Fixed Resistances/Immunities/Vulnerabilities on `monster/[id]`

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -341,7 +341,7 @@ const actions = computed(() => {
 
   // sort monster actions according to the value of their 'order' field
   Object.keys(actionsByType).forEach((type) => {
-    actionsByType[type].sort((a, b) => a['order'] - b['order']);
+    actionsByType[type].sort((a, b) => a['order_in_statblock'] - b['order_in_statblock']);
   });
 
   return actionsByType;

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -141,19 +141,20 @@
       </ul>
 
       <!-- RESISTANCES, VULNERABILITY AND IMMUNITIES -->
-      <ul
-        v-for="(data, title) in resistancesAndVulnerabilities"
-        :key="title"
-      >
-        <label class="inline font-bold after:content-['_']">{{ title }}</label>
-        <li
-          v-for="field in data"
-          :key="field.name"
-          class="inline after:content-[',_'] last:after:content-[]"
+      <dl>
+        <div
+          v-for="(text, title) in resistancesAndVulnerabilities"
+          :key="title"
+          class="flex gap-1"
         >
-          {{ field.name }}
-        </li>
-      </ul>
+          <dt class="font-bold">
+            {{ title + " " }}
+          </dt>
+          <dd class="capitalize">
+            {{ text }}
+          </dd>
+        </div>
+      </dl>
 
       <!-- SENSES -->
       <ul id="senses">
@@ -384,43 +385,28 @@ const senses = computed(() => {
   return senses;
 });
 
-// format monster damage/condition vulnerabilities, resistances & immunities
+// Format monster immunities, resistances, and vulnerabilities as an iterable
+// object suitable for rendering via a `v-for` directive
 const resistancesAndVulnerabilities = computed(() => {
   const { value: monsterData } = monster;
   if (!monsterData) return {};
 
-  const resists = {
-    damage_resistances: monsterData.damage_resistances,
-    damage_vulnerabilities: monsterData.damage_vulnerabilities,
-    damage_immunities: monsterData.damage_immunities,
-    condition_immunities: monsterData.condition_immunities,
+  // destructure deeply-nested data
+  const { resistances_and_immunities: resImmunityData } = monsterData;
+  const {
+    damage_resistances_display: dmgRes,
+    damage_immunities_display: dmgImmune,
+    damage_vulnerabilities_display: dmgVuln,
+    condition_immunities_display: conditionImmune,
+  } = resImmunityData;
+
+  // assemble output object, conditionally inlcuding only non-nullish fields
+  return {
+    ...(dmgRes && { 'Damage Resistances': dmgRes }),
+    ...(dmgImmune && { 'Damage Immunities': dmgImmune }),
+    ...(dmgVuln && { 'Damage Vulnerabilities': dmgVuln }),
+    ...(conditionImmune && { 'Condition Immunities': conditionImmune }),
   };
-
-  // helper function: formats 'Bludgeoning, Piercing and Slashing from Nonmagical Attacks'
-  const formatNonMagicAttacks = (field) => {
-    const damageTypesToSub = ['Bludgeoning', 'Slashing', 'Piercing'];
-    const sub = 'Bludgeoning, Piercing and Slashing from Nonmagical Attacks';
-    return [
-      ...field.filter(res => !damageTypesToSub.includes(res.name)),
-      { name: sub },
-    ];
-  };
-
-  // conditionally apply non-magical attack resist/immunity formatting
-  resists.damage_immunities = monsterData.nonmagical_attack_immunity
-    ? formatNonMagicAttacks(resists.damage_immunities)
-    : resists.damage_immunities;
-  resists.damage_resistances = monsterData.nonmagical_attack_resistance
-    ? formatNonMagicAttacks(resists.damage_resistances)
-    : resists.damage_resistances;
-
-  // filter empty keys, re-format object for display, and return
-  return Object.entries(resists)
-    .filter(([_, value]) => value.length > 0)
-    .reduce((acc, [key, value]) => {
-      acc[snakeToTitleCase(key)] = value;
-      return acc;
-    }, {});
 });
 
 const mode = ref(route.query.mode || 'normal');


### PR DESCRIPTION
## Description

This PR fixes a bug on the staging branch where the `/monsters/[id]` didn't load due to problems with the page component indexing into fields of the API response that have since been renamed. The fields in question were those that handles Resistances, Immunities and Vulnerabilities.

Fixing this required a rewriting `resistancesAndVulnerabilities` computed value so that the correct fields were gathered into an iterable object suitable for rendering via the `v-for` directive.

## Related Issue

Closes #703 

## How was this tested?

The code was tested on a local Nuxt development server to confirm that this PR fixes the issue. Other pages were also poked at to make sure that there were no unintended breakages introduced.

Our Vitest suite ran without error (`npm run test` ) and the bulid process also completed without error (`npm run build`)

