### PR TITLE
[BUGFIX] Fixed object keys for Weapon data on `/equipment/[id]`

### DIFF
--- a/pages/equipment/[id].vue
+++ b/pages/equipment/[id].vue
@@ -24,14 +24,17 @@
             Damage Type
           </dt>
           <dd class="capitalize">
-            {{ item.weapon.damage_type?.split('/').slice(-2)[0] ?? '' }}
+            {{ item.weapon.damage_type.name }}
           </dd>
           <template v-if="item.weapon.properties?.length > 0">
             <dt class="font-bold">
               Properties
             </dt>
             <dd class="capitalize">
-              {{ item.weapon.properties.map((prop) => prop).join(', ') }}
+              <!-- iterate over weapon props, generate csv list of props -->
+              {{ item.weapon.properties.map(
+                (p) => (p.property.name + (p.detail ? ` (${p.detail})` : "")),
+              ).join(', ') }}
             </dd>
           </template>
           <template v-if="item.weapon.is_reach">
@@ -64,8 +67,7 @@
 
       <!-- ITEM CARD FOR ARMOR -->
       <div v-else-if="item.armor">
-        <!-- TODO: whether armor is light/med/heavy not rtn'd by API -->
-        <p>{{ `Armor (${'TODO'})` }}</p>
+        <p>{{ "Armor" + (item.armor.category ? ` (${item.armor.category})` : "") }}</p>
         <md-viewer :text="item.desc" />
         <dl class="grid grid-cols-[6rem_1fr]">
           <dt class="font-bold">


### PR DESCRIPTION
## Description

This PR fixes a bug on the `/equipment/[id]` page where Items with a Weapon property were throwing TypeErrors in the browser:

`staging` (before):

<img width="1060" alt="Screenshot 2025-06-05 at 13 00 49" src="https://github.com/user-attachments/assets/b2ec7cb0-308a-4a08-a68e-aeefcaa281a5" />

These bugs were introduced by recent changes to the Weapon model on API, so that the frontend was no longer index into the JSON payload returned by the API correctly. Once these object keys were updated, the page renders as intended:

Feature branch (after):

<img width="852" alt="Screenshot 2025-06-05 at 13 04 14" src="https://github.com/user-attachments/assets/87e3b893-6ebc-4b41-9b12-7ade435c6da2" />


## Related Issue

Closes #705 

## How was this tested?

- Visually inspected on Nuxt development server (pulling data from the `staging` branch of the Open5e API)
- A build was attempted by running the `npm run build` command. It suceeded without error
- All tests passing (`npm run test`)

