### PR TITLE
[BUGFIX] ClassFeature sorting bug on subclasses page

### DIFF
--- a/pages/classes/[className]/[subclass].vue
+++ b/pages/classes/[className]/[subclass].vue
@@ -43,7 +43,7 @@ const features = computed(() => {
   const features = subclassData.value.features;
   if (!features) return [];
   return [...features].sort(
-    (a, b) => a.gained_at[0].level - b.gained_at[0].level,
+    (a, b) => (a.gained_at?.[0]?.level ?? 1) - (b.gained_at?.[0]?.level ?? 1),
   );
 });
 </script>


### PR DESCRIPTION
## Description

This PR fixes an issue where sorting subclass features by the first entry in their `gained_at` array would throw an error when this array was empty.

The issue was fixed by using the optional chaining (`?.`) to avoid errors from indexing into empty arrays, and the nullish coalescing operator (`??`) to provide a default level of 1 for sorting purposes in 

## Related Issue

Closes #716 

## How was this tested?
- Poking around the Nuxt test server running the feature branch, pulling data from a Django test server running the `staging` branch of the API.
- Ran `npm run build` to test the build process. Executed without error
- Ran test suite using `npm run test`. All tests are passing
