### PR TITLE
[BUGFIX] Improved legibility of subclass list on `/classes/[className]`

### DIFF
--- a/pages/classes/[className]/index.vue
+++ b/pages/classes/[className]/index.vue
@@ -4,25 +4,6 @@
     class="docs-container container"
   >
     <h1>{{ classData.name }}</h1>
-    <ul
-      v-if="subclasses?.length > 0"
-      class="mt-2"
-    >
-      <p class="inline font-bold after:content-[':_']">
-        Subclasses
-      </p>
-      <li
-        v-for="subclass in subclasses"
-        :key="subclass.name"
-        class="inline"
-      >
-        <nuxt-link
-          :to="`/classes/${useRoute().params.className}/${subclass.key}`"
-        >
-          {{ subclass.name }}
-        </nuxt-link>
-      </li>
-    </ul>
     <section>
       <h2>Class Features</h2>
       <p>As a {{ classData.name }} you gain the following features.</p>
@@ -61,6 +42,26 @@
           :text="equipment.desc"
         />
       </div>
+    </section>
+    <section v-if="subclasses?.length > 0">
+      <h3>Subclasses</h3>
+      <ul class="mt-2 flex flex-wrap gap-x-2">
+        <li
+          v-for="subclass in subclasses"
+          :key="subclass.name"
+          class="after:ml-2 after:content-['|'] last:after:content-none"
+        >
+          <nuxt-link
+            :to="`/classes/${useRoute().params.className}/${subclass.key}`"
+          >
+            {{ subclass.name }}
+          </nuxt-link>
+          <SourceTag
+            :text="subclass.document.key"
+            :title="subclass.document.name"
+          />
+        </li>
+      </ul>
     </section>
 
     <!-- Class Table -->
@@ -113,7 +114,7 @@ const { data: classData } = useFindOne(
 
 // fetch subclasses to generate links
 const { data: subclasses } = useFindMany(API_ENDPOINTS.classes, {
-  fields: ['key', 'name'].join(','),
+  fields: ['key', 'name', 'document'].join(','),
   subclass_of: useRoute().params.className,
 });
 

--- a/tests/unit/pages/class.test.tsx
+++ b/tests/unit/pages/class.test.tsx
@@ -1,5 +1,6 @@
 import { test, expect } from 'vitest';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
+import { unref } from 'vue';
 import ClassPage from '~/pages/classes/[className]/index.vue';
 
 const { data: className } = useFindOne('v2/classes', 'srd_barbarian');
@@ -141,8 +142,12 @@ mockNuxtImport('useFindMany', () => {
   return () => ({
     data: [
       {
-        key: 'srd_barbarian',
-        name: 'Barbarian',
+        key: 'srd_path-of-the-berserker',
+        name: 'Path of the Berserker',
+        document: {
+          name: 'System Reference Document 5.1',
+          key: 'srd-2014',
+        },
       },
     ],
   });


### PR DESCRIPTION
## Description

This PR fixes a visual bug on the Class single-view page where the list of links to a given class's subclasses was difficult to read:

<img width="800" alt="452262655-b49b47c1-0102-46e1-908f-d37bad2a4a5d" src="https://github.com/user-attachments/assets/88b9697b-c180-48f7-89f8-e84e9f3c8679" />

Yuck. This list was refactored so that the links are more clearly visually spaced, and their source document is also referenced. The list was also moved further down the class list (it doesn't need to be at the top, we already have the links to subclasses in the navbar).

<img width="800" alt="Screenshot 2025-06-07 at 11 20 39" src="https://github.com/user-attachments/assets/315ac5b9-c748-49ba-bc00-64d9d0f87c02" />

This presentation still isn't perfect, but it is a big improvement.


## Related Issue

Closes #715 

## How was this tested?

- Visually tested on the Nuxt test server (pulling data from a Django test server running the `staging` branch of the API.
- `npm run test` (one test was failing due to the subclasses' documents not being included in the mocked data, this has been fixed)
- `npm run build` to confim that the build completes without error

