### PR TITLE
[BUGFIX] Removed SRD 5.2 Classes from NavMenu

### DIFF
--- a/components/NavMenu.vue
+++ b/components/NavMenu.vue
@@ -31,7 +31,7 @@
       >
         <li
           v-for="subroute in section.subroutes"
-          :key="subroute.title"
+          :key="subroute?.title"
         >
           <NavMenuLink
             :to="`${subroute.url}`"
@@ -61,8 +61,9 @@
 </template>
 
 <script setup>
-const { data: classes } = useFindMany(API_ENDPOINTS.classes, {
-  fields: ['name', 'key', 'subclass_of'].join(),
+const { data: classes } = await useFindMany(API_ENDPOINTS.classes, {
+  fields: ['name', 'key', 'document', 'subclass_of'].join(),
+  document__fields: ['key'].join(),
 });
 
 const crumbs = useBreadcrumbs();
@@ -84,8 +85,10 @@ const classSubroutes = computed(() => {
 
   // generate subroutes to other base-classes
   const output = baseClasses.map((item) => {
+    // filter out srd-2024 classes until better UX solution developed (#720)
+    if (item.document.key === 'srd-2024') return;
     return { title: item.name, url: `/classes/${item.key}` };
-  });
+  }).filter((item) => item); // filter nullish items from output
 
   // if we are on a sub-route of a base-class, get other sub-class routes
   if (crumbs.value.length >= 2) {


### PR DESCRIPTION
## Description

This PR resolves a UI issue where the SRD 5.2 classes were bloating the Class list in the NavMenu component (see screenshots below).

This was achieved by filtering out the SRD-2024 classes using an early return while mapping across the class list.


## Related Issue

Closes #721 

## How was this tested?

- Run `npm run build` to ensure build process completes without error
- Run `npx run test` (all tests are passing)
- Spot testing on the Nuxt development server (pulling data from the `staging` branch of the API)

## Screenshots

Before:

<img width="400" alt="Screenshot 2025-06-13 at 10 18 20" src="https://github.com/user-attachments/assets/f9b3920e-12c6-4dc1-9e17-00b97e04f449" />

After:

<img width="400" alt="Screenshot 2025-06-13 at 11 16 33" src="https://github.com/user-attachments/assets/d625e0e0-b692-4650-aa44-1bd9f7ef42c1" />



