### PR TITLE
Dice Roller Enhancements

### DIFF
--- a/components/MonsterAbilities.vue
+++ b/components/MonsterAbilities.vue
@@ -85,13 +85,19 @@
           </td>
           <td
             :class="rollableLinkClasses"
-            @click="useDiceRoller(data.mod)"
+            @click="useDiceRoller(data.mod, {
+              title: `${ability} Check`,
+              subtitle: monster.name,
+            })"
           >
             {{ useFormatModifier(data.mod) }}
           </td>
           <td
             :class="rollableLinkClasses"
-            @click="useDiceRoller(data.save)"
+            @click="useDiceRoller(data.save, {
+              title: `${ability} Save`,
+              subtitle: monster.name,
+            })"
           >
             {{ useFormatModifier(data.save) }}
           </td>

--- a/components/PageNotifications.vue
+++ b/components/PageNotifications.vue
@@ -28,7 +28,8 @@
       <li
         v-for="(notification, index) in notifications"
         :key="index"
-        class="mt-1 border-y-2 border-red-400 bg-gray-100 px-3 py-2 dark:bg-slate-900"
+        class="my-2 cursor-pointer border-y-2 border-fireball bg-gray-100 px-3 py-2 transition-all duration-150 hover:border-mana dark:bg-slate-900"
+        @click="remove(index)"
       >
         <p class="my-0 font-serif text-xs font-light">
           {{ notification.title }}
@@ -37,12 +38,6 @@
           <p class="m-0 text-4xl">
             {{ notification.body }}
           </p>
-          <button
-            class="float-right font-bold text-blood transition-all hover:text-red-400"
-            @click="remove(index)"
-          >
-            &#x2715;
-          </button>
         </div>
         <div class="m-0 p-0 text-sm">
           {{ notification.footer }}

--- a/components/PageNotifications.vue
+++ b/components/PageNotifications.vue
@@ -12,7 +12,7 @@
 </script>
 
 <template>
-  <div class="fixed bottom-0 right-4 m-0 flex min-w-36 flex-col-reverse p-0">
+  <div class="fixed bottom-0 right-4 m-0 flex flex-col-reverse p-0">
     <!-- Only render 'clear all' btn when notifs array populated -->
     <div
       v-if="notifications.length"

--- a/components/PageNotifications.vue
+++ b/components/PageNotifications.vue
@@ -39,7 +39,7 @@
             {{ notification.body }}
           </p>
         </div>
-        <div class="m-0 p-0 text-sm">
+        <div class="m-0 p-0 text-sm text-basalt">
           {{ notification.footer }}
         </div>
       </li>

--- a/components/PageNotifications.vue
+++ b/components/PageNotifications.vue
@@ -13,6 +13,7 @@
 
 <template>
   <div class="fixed bottom-0 right-8 m-0 flex min-w-36 flex-col-reverse p-0">
+    <!-- Only render 'clear all' btn when notifs array populated -->
     <div
       v-if="notifications.length"
       class="grid justify-end bg-white/80 dark:bg-darkness/80"
@@ -24,22 +25,32 @@
         Clear All &#x2715;
       </button>
     </div>
-    <ul class="flex flex-col">
+
+    <!-- Notification list -->
+    <ul class="flex flex-col text-center ">
       <li
         v-for="(notification, index) in notifications"
         :key="index"
-        class="my-2 cursor-pointer border-y-2 border-fireball bg-gray-100 px-3 py-2 transition-all duration-150 hover:border-mana dark:bg-slate-900"
+        class="my-2 cursor-pointer border-y-2 border-fireball bg-gray-100 px-3 py-2 duration-150 hover:border-mana dark:bg-slate-900"
         @click="remove(index)"
       >
-        <p class="my-0 font-serif text-xs font-light">
-          {{ notification.title }}
-        </p>
-        <div class="my-0 flex justify-between align-middle font-bold">
-          <p class="m-0 text-4xl">
+        <div class="text-sm">
+          <span class="my-0 py-0 font-serif font-light capitalize">
+            {{ notification.title }}
+          </span>
+          <span
+            v-if="notification.subtitle"
+            class="uppercase text-basalt before:content-['_|_'] dark:text-smoke"
+          >
+            {{ notification.subtitle }}
+          </span>
+        </div>
+        <div class="my-0 flex justify-center align-middle font-bold">
+          <p class="m-0 text-5xl">
             {{ notification.body }}
           </p>
         </div>
-        <div class="m-0 p-0 text-sm text-basalt">
+        <div class="m-0 p-0 text-sm text-basalt dark:text-smoke">
           {{ notification.footer }}
         </div>
       </li>

--- a/components/PageNotifications.vue
+++ b/components/PageNotifications.vue
@@ -27,31 +27,43 @@
     </div>
 
     <!-- Notification list -->
-    <ul class="flex flex-col text-center ">
+    <ul class="flex w-min flex-col text-nowrap text-center">
       <li
         v-for="(notification, index) in notifications"
         :key="index"
-        class="my-2 cursor-pointer border-y-2 border-fireball bg-gray-100 px-3 py-2 duration-150 hover:border-mana dark:bg-slate-900"
+        class="my-2 cursor-pointer border-y-2 border-blood bg-gray-100 px-3 py-2 duration-150 hover:border-fireball dark:bg-slate-900"
         @click="remove(index)"
       >
-        <div class="text-sm">
-          <span class="my-0 py-0 font-serif font-light capitalize">
-            {{ notification.title }}
-          </span>
-          <span
-            v-if="notification.subtitle"
-            class="uppercase text-basalt before:content-['_|_'] dark:text-smoke"
-          >
-            {{ notification.subtitle }}
-          </span>
+        <!-- SMALL VARIATION: use for all notifications except the latest -->
+        <div 
+          v-if="index < notifications.length - 1"
+          class="text-nowrap text-right text-xs capitalize"
+        >
+          <span class="font-serif">{{ notification.title }}</span>
+          <span v-if="notification.subtitle" class="before:content-['_|_']">{{ notification.subtitle }}</span>
+          <span class="mx-2 text-base font-bold before:content-['_']">{{ notification.body }}</span>
         </div>
-        <div class="my-0 flex justify-center align-middle font-bold">
-          <p class="m-0 text-5xl">
-            {{ notification.body }}
-          </p>
-        </div>
-        <div class="m-0 p-0 text-sm text-basalt dark:text-smoke">
-          {{ notification.footer }}
+        <!-- EXPANDED VARIATION: use for the most recent notification -->
+        <div v-else>
+          <div class="text-sm">
+            <span class="my-0 py-0 font-serif font-light capitalize">
+              {{ notification.title }}
+            </span>
+            <span
+              v-if="notification.subtitle"
+              class="uppercase text-basalt before:content-['_|_'] dark:text-smoke"
+            >
+              {{ notification.subtitle }}
+            </span>
+          </div>
+          <div class="my-0 flex justify-center align-middle font-bold">
+            <p class="m-0 text-5xl">
+              {{ notification.body }}
+            </p>
+          </div>
+          <div class="m-0 p-0 text-sm text-basalt dark:text-smoke">
+            {{ notification.footer }}
+          </div>
         </div>
       </li>
     </ul>

--- a/components/PageNotifications.vue
+++ b/components/PageNotifications.vue
@@ -12,46 +12,46 @@
 </script>
 
 <template>
-  <div class="fixed bottom-0 right-8 m-0 flex min-w-36 flex-col-reverse p-0">
+  <div class="fixed bottom-0 right-4 m-0 flex min-w-36 flex-col-reverse p-0">
     <!-- Only render 'clear all' btn when notifs array populated -->
     <div
       v-if="notifications.length"
-      class="grid justify-end bg-white/80 dark:bg-darkness/80"
+      class="grid justify-end  dark:bg-darkness/80"
     >
       <button
-        class="mr-2 font-bold text-blood hover:text-red-400"
+        class="my-1 rounded bg-blood px-3 py-1 font-sans font-bold text-white hover:bg-red-400"
         @click="clear()"
       >
-        Clear All &#x2715;
+        CLEAR ALL &#x2715;
       </button>
     </div>
 
     <!-- Notification list -->
-    <ul class="flex w-min flex-col text-nowrap text-center">
+    <ul class="flex w-min flex-col items-end text-nowrap text-center">
       <li
         v-for="(notification, index) in notifications"
         :key="index"
-        class="my-2 cursor-pointer border-y-2 border-blood bg-gray-100 px-3 py-2 duration-150 hover:border-fireball dark:bg-slate-900"
+        class="items-right my-2 w-min cursor-pointer border-y-2 border-blood bg-gray-100/95 px-3 py-2 duration-150  hover:border-fireball dark:bg-slate-900/95"
         @click="remove(index)"
       >
         <!-- SMALL VARIATION: use for all notifications except the latest -->
         <div 
           v-if="index < notifications.length - 1"
-          class="text-nowrap text-right text-xs capitalize"
+          class="w-min text-nowrap text-right text-xs capitalize"
         >
           <span class="font-serif">{{ notification.title }}</span>
-          <span v-if="notification.subtitle" class="before:content-['_|_']">{{ notification.subtitle }}</span>
-          <span class="mx-2 text-base font-bold before:content-['_']">{{ notification.body }}</span>
+          <span v-if="notification.subtitle" class="uppercase before:content-['_|_']">{{ notification.subtitle }}</span>
+          <span class="text-base font-bold before:content-['_']">{{ notification.body }}</span>
         </div>
         <!-- EXPANDED VARIATION: use for the most recent notification -->
         <div v-else>
-          <div class="text-sm">
+          <div class="text-base">
             <span class="my-0 py-0 font-serif font-light capitalize">
               {{ notification.title }}
             </span>
             <span
               v-if="notification.subtitle"
-              class="uppercase text-basalt before:content-['_|_'] dark:text-smoke"
+              class="text-sm uppercase text-basalt before:content-['_|_'] dark:text-smoke"
             >
               {{ notification.subtitle }}
             </span>

--- a/composables/useDiceRoller.ts
+++ b/composables/useDiceRoller.ts
@@ -34,6 +34,7 @@ export function useDiceRoller(
 
   const formattedModifier = useFormatModifier(modifier, {
     showZero: false,
+    spaceAfterOrdinal: true,
   });
 
   const formattedDiceSignature = `${number}d${dice} ${formattedModifier}`;
@@ -45,6 +46,7 @@ export function useDiceRoller(
   // push results to notifications
   addNotif({
     title: notifTitle,
+    subtitle: options?.subtitle ?? '',
     body: result,
     footer: `[ ${rolls.join(', ')} ] ${formattedModifier}`,
   });

--- a/composables/useDiceRoller.ts
+++ b/composables/useDiceRoller.ts
@@ -3,7 +3,15 @@ import { useNotifications } from './useNotifications';
 
 const { addNotif } = useNotifications();
 
-export function useDiceRoller(input: string | number) {
+type UseDiceRollerOptions = {
+  title?: string;
+  subtitle?: string;
+}
+
+export function useDiceRoller(
+  input: string | number,
+  options: UseDiceRollerOptions,
+) {
   // make sure dice signature is a string
   const signature = typeof input === 'string' ? input : input.toString();
 
@@ -23,13 +31,20 @@ export function useDiceRoller(input: string | number) {
   // add up the results and add the modifier
   const result = rolls.reduce((total, roll) => total + roll) + modifier;
 
+
   const formattedModifier = useFormatModifier(modifier, {
     showZero: false,
   });
 
+  const formattedDiceSignature = `${number}d${dice} ${formattedModifier}`;
+
+  const notifTitle = options?.title 
+    ? `${options.title}`
+    : `Rolling ${formattedDiceSignature}`;
+  
   // push results to notifications
   addNotif({
-    title: `Rolling ${number}d${dice} ${formattedModifier}`,
+    title: notifTitle,
     body: result,
     footer: `[ ${rolls.join(', ')} ] ${formattedModifier}`,
   });

--- a/composables/useFormatModifier.ts
+++ b/composables/useFormatModifier.ts
@@ -6,6 +6,7 @@ export const useFormatModifier = (
   options?: {
     inputType?: 'modifier' | 'score';
     showZero?: boolean;
+    spaceAfterOrdinal?: boolean;
   },
 ) => {
   if (input === undefined) return '-';
@@ -17,12 +18,14 @@ export const useFormatModifier = (
   // cast input to number
   const inputNum = typeof input === 'string' ? parseInt(input) : input;
 
-  // handle 0s is showZero option is false
+  // handle 0s if showZero option is false
   if (inputNum === 0 && !showZero) return '';
 
   // convert score to mod
   const mod = type === 'score' ? Math.floor((inputNum - 10) / 2) : inputNum;
 
-  // remove '-' from negative numbers, add back a '+' OR '-'
-  return (mod < 0 ? '-' : '+') + mod.toString().replace('-', '');
+  return (
+    (mod < 0 ? '-' : '+') // generate ordinal
+    + (options?.spaceAfterOrdinal ? ' ' : '') // add space before ordinal
+    + mod.toString().replace('-', '')); // rmv '-' from stringified mod
 };

--- a/composables/useNotifications.ts
+++ b/composables/useNotifications.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue';
 
 type Notification = {
   title: string;
+  subtitle?: string;
   body: string | number;
   footer: string;
 };

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -87,7 +87,10 @@
       </dt>
       <dd
         class="w-min cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
-        @click="useDiceRoller(initiativeBonus, { title: 'Initiative', subtitle: monster.name })"
+        @click="useDiceRoller(initiativeBonus, { 
+          title: 'Initiative',
+          subtitle: monster.name 
+        })"
       >
         {{ useFormatModifier(initiativeBonus) }}
       </dd>
@@ -101,7 +104,10 @@
         <span
           v-if="monster.hit_dice"
           class="cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
-          @click="useDiceRoller(monster.hit_dice)"
+          @click="useDiceRoller(monster.hit_dice, {
+             title: 'Hit Points',
+             subtitle: monster.name
+          })"
         >
           {{ `(${monster.hit_dice})` }}
         </span>
@@ -146,7 +152,10 @@
           v-for="(modifier, skill) in monster.skill_bonuses"
           :key="skill"
           class="inline cursor-pointer font-bold capitalize text-blood after:text-black after:content-[',_'] last:after:content-[] hover:text-black dark:after:text-white dark:hover:text-fog"
-          @click="useDiceRoller(modifier.toString())"
+          @click="useDiceRoller(modifier.toString(), {
+             title: skill,
+             subtitle: monster.name
+          })"
         >
           {{ `${skill} ${useFormatModifier(modifier)}` }}
         </li>
@@ -265,7 +274,10 @@
           <span
             v-if="action.uses_type === 'RECHARGE_ON_ROLL'"
             class="cursor-pointer font-bold text-blood before:text-black before:content-['_('] after:text-black after:content-[')_'] hover:text-black dark:before:text-white dark:after:text-white dark:hover:text-white"
-            @click="useDiceRoller('1d6+0', { title: `${action.name} – Recharge`})"
+            @click="useDiceRoller('1d6+0', {
+              title: `${action.name} Recharge`,
+              subtitle: monster.name,
+            })"
           >
             {{
               'Recharge '

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -87,7 +87,7 @@
       </dt>
       <dd
         class="w-min cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
-        @click="useDiceRoller(initiativeBonus)"
+        @click="useDiceRoller(initiativeBonus, { title: 'Initiative', subtitle: monster.name })"
       >
         {{ useFormatModifier(initiativeBonus) }}
       </dd>
@@ -265,7 +265,7 @@
           <span
             v-if="action.uses_type === 'RECHARGE_ON_ROLL'"
             class="cursor-pointer font-bold text-blood before:text-black before:content-['_('] after:text-black after:content-[')_'] hover:text-black dark:before:text-white dark:after:text-white dark:hover:text-white"
-            @click="useDiceRoller('1d6+0')"
+            @click="useDiceRoller('1d6+0', { title: `${action.name} – Recharge`})"
           >
             {{
               'Recharge '


### PR DESCRIPTION
## Description

This PR extends the functionality and improves the styles of the on-page Dice Roller as follows:

- An optional `subtitle` prop can be passed to the `useDiceRoller` composable (this is currently used to display a Monster's name when dice are rolled on its page).
- The most recent roll result has been made more prominent, older results have been made smaller.
- Results can be removed from the notification list by clicking on them 

Light Mode:
<img width="600" alt="Screenshot 2025-06-19 at 21 49 54" src="https://github.com/user-attachments/assets/5b143215-2224-4f30-bb92-9047a59e584b" />

Dark Mode:
<img width="600" alt="Screenshot 2025-06-19 at 21 49 44" src="https://github.com/user-attachments/assets/ec9d0068-0826-4f45-a9b3-5fcf72794fa9" />

The functional changes are purely extensions, existing invocations of the `useDiceRoller` composable work as before. The new `subtitle` can be passed via the `options` property:


From `/pages/monster/[id].vue` (TailwindCSS classes omitted for brevity)
```
      <dt>Initiative Bonus</dt>
      <dd
        @click="useDiceRoller(initiativeBonus, { 
          title: 'Initiative',
          subtitle: monster.name 
        })"
      >
        {{ useFormatModifier(initiativeBonus) }}
      </dd>
```
## Related Issue

Closes #681 

## How was this tested?

- Visually inspected on Nuxt test server (pulling data from the API `staging` branch)
- `npm run test` (all passing)
- `npm run build` (build process completes without error)

