### PR TITLE
Introducing TS vue-tsc

### DIFF
--- a/components/EncounterBuilderMonsterSearch.vue
+++ b/components/EncounterBuilderMonsterSearch.vue
@@ -85,7 +85,7 @@ import { ref, watchEffect } from 'vue';
 import { useAPI, API_ENDPOINTS } from '~/composables/api';
 import { useSourcesList } from '~/composables/sources';
 import type { Monster } from '~/types/monster';
-
+import type { RawMonster } from '~/types/APIMonster';
 const emit = defineEmits<{
   (e: 'select', monster: Monster): void;
 }>();
@@ -103,16 +103,29 @@ const { sources } = useSourcesList();
 
 const optionsRef = ref<HTMLElement | null>(null);
 
-// Simplified monster mapping function
-const mapMonsterFromAPI = (monster: Record<string, string | number>): Monster => ({
-  id: monster.slug || monster.key || monster.id || '',
-  name: monster.name,
-  challenge_rating:
-    monster.challenge_rating || monster.challenge_rating_text || '0',
-  challenge_rating_decimal: monster.challenge_rating_decimal || 0,
-  document: monster.document,
-});
+// Improved monster mapping function
+const mapMonsterFromAPI = (monster: RawMonster): Monster => {
+  const base = {
+    id: String(monster.slug || monster.key || monster.id || ''),
+    name: String(monster.name) || '',
+    challenge_rating: String(
+      monster.challenge_rating || monster.challenge_rating_text || '0'
+    ),
+    challenge_rating_decimal: Number(monster.challenge_rating_decimal) || 0,
+  };
 
+  if (monster.document !== undefined) {
+    return {
+      ...base,
+      document: {
+        name: monster.document.name,
+        key: monster.document.key,
+      },
+    };
+  }
+
+  return base;
+};
 let debounceTimeout: ReturnType<typeof setTimeout>;
 
 // Function to check if we're near the bottom of the scroll
@@ -137,7 +150,7 @@ const loadMore = async () => {
 
   isLoadingMore.value = true;
   try {
-    const response = await findPaginated({
+    const response = await findPaginated<RawMonster>({
       endpoint: API_ENDPOINTS.monsters,
       sources: sources.value,
       itemsPerPage: 25,
@@ -181,7 +194,7 @@ watchEffect(
     debounceTimeout = setTimeout(async () => {
       isSearching.value = true;
       try {
-        const response = await findPaginated({
+        const response = await findPaginated<RawMonster>({
           endpoint: API_ENDPOINTS.monsters,
           sources: sources.value,
           itemsPerPage: 25,

--- a/components/EncounterBuilderMonsterSearch.vue
+++ b/components/EncounterBuilderMonsterSearch.vue
@@ -114,18 +114,17 @@ const mapMonsterFromAPI = (monster: RawMonster): Monster => {
     challenge_rating_decimal: Number(monster.challenge_rating_decimal) || 0,
   };
 
-  if (monster.document !== undefined) {
-    return {
+  return !monster.document
+    ? base
+    : {
       ...base,
       document: {
-        name: monster.document.name,
-        key: monster.document.key,
-      },
+        name: monster.document.name || '',
+        key: monster.document.key || '',
+      }
     };
-  }
-
-  return base;
 };
+
 let debounceTimeout: ReturnType<typeof setTimeout>;
 
 // Function to check if we're near the bottom of the scroll

--- a/components/EncounterBuilderPartyBuilder.vue
+++ b/components/EncounterBuilderPartyBuilder.vue
@@ -48,6 +48,7 @@
 
 <script setup lang="ts">
 import { usePartyStore } from '~/composables/useParty';
+import { onMounted } from 'vue';
 
 const store = usePartyStore();
 const { partyRows, addPartyRow, removePartyRow }

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -48,7 +48,7 @@ export const useAPI = () => {
 
       return res.data.results as Record<string, unknown>[];
     },
-    findPaginated: async (options: {
+    findPaginated: async <T = Record<string, unknown>> (options: {
       endpoint: string;
       sources: string[];
       pageNo?: number;
@@ -66,7 +66,6 @@ export const useAPI = () => {
         isSortDescending = false,
         queryParams = {},
       } = options;
-
       const formattedSources = sources.join(',');
       const res = await api.get(endpoint, {
         params: {
@@ -80,7 +79,7 @@ export const useAPI = () => {
 
       const data = res.data as {
         count: number;
-        results: Record<string, unknown>[];
+        results: T[];
         next: string | null;
         previous: string | null;
       };

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,9 @@
         "prettier-plugin-tailwindcss": "^0.3.0",
         "pretty-quick": "^3.1.3",
         "sass": "^1.62.1",
+        "typescript": "^5.8.3",
         "vitest": "^1.6.1",
-        "vue-tsc": "^2.1.10"
+        "vue-tsc": "^2.2.10"
       },
       "engines": {
         "node": "20.x"
@@ -6765,9 +6766,9 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.8.tgz",
-      "integrity": "sha512-rrzB0wPGBvcwaSNRriVWdNAbHQWSf0NlGqgKHK5mEkXpefjUlVRP62u03KvwZpvKVjRnBIQ/Lwre+Mx9N6juUQ==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.10.tgz",
+      "integrity": "sha512-+yNoYx6XIKuAO8Mqh1vGytu8jkFEOH5C8iOv3i8Z/65A7x9iAOXA97Q+PqZ3nlm2lxf5rOJuIGI/wDtx/riNYw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -20807,14 +20808,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.8.tgz",
-      "integrity": "sha512-jBYKBNFADTN+L+MdesNX/TB3XuDSyaWynKMDgR+yCSln0GQ9Tfb7JS2lr46s2LiFUT1WsmfWsSvIElyxzOPqcQ==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.10.tgz",
+      "integrity": "sha512-jWZ1xSaNbabEV3whpIDMbjVSVawjAyW+x1n3JeGQo7S0uv2n9F/JMgWW90tGWNFRKya4YwKMZgCtr0vRAM7DeQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "~2.4.11",
-        "@vue/language-core": "2.2.8"
+        "@vue/language-core": "2.2.10"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "prettier-plugin-tailwindcss": "^0.3.0",
     "pretty-quick": "^3.1.3",
     "sass": "^1.62.1",
+    "typescript": "^5.8.3",
     "vitest": "^1.6.1",
-    "vue-tsc": "^2.1.10"
+    "vue-tsc": "^2.2.10"
   },
   "dependencies": {
     "@headlessui/vue": "^1.7.14",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,9 +20,9 @@
   "include": [
     "nuxt.config.ts",
     // TODO: `vue-tsc` required to type-check .vue files (issue #714)
-    // "pages/**/*.vue",
-    // "layouts/default.vue",
-    // "components/**/*.vue",
+    "pages/**/*.vue",
+    "layouts/default.vue",
+    "components/**/*.vue",
     "composables/**/*.ts",
     "plugins/**/*.ts",
     "store/**/*.ts"

--- a/types/APIMonster.ts
+++ b/types/APIMonster.ts
@@ -1,0 +1,15 @@
+// raw data coming from api
+
+export interface RawMonster {
+  id?: string | number;
+  key?: string;
+  slug?: string;
+  name: string;
+  challenge_rating: string | number;
+  challenge_rating_text?: string;
+  challenge_rating_decimal?: number;
+  document?: {
+    name: string;
+    key: string;
+  }
+}


### PR DESCRIPTION
## Description

Introduced vue-tsc as well as created a RawMonster interface and updated the mapMonsterFromAPI function for stronger type interference to avoid TS from throwing type errors. Moreover, added a generic type for findPaginated so you can define what you expect or default to Record<string, unknown> for reverse compatibility. 

RawMonster Should help with visibility for what type of data is coming from the API.

## Related Issue

*Closes https://github.com/open5e/open5e/issues/714*

## How was this tested?
I ran npm run test and it passed all tests.
As well as npm run dev runs fine.

***Draft PR***


