### PR TITLE
fix: app fails when magic item rarity is null

### DIFF
--- a/app/pages/magic-items/[id].vue
+++ b/app/pages/magic-items/[id].vue
@@ -6,7 +6,7 @@
       </h1>
       <p>
         <em>
-          {{ item.category.name }}, {{ item.rarity.name }}
+          {{ item.category.name }}, {{ item.rarity?.name ?? 'Rarity unspecified' }}
           <span v-show="item.requires_attunement">
             ({{ 'requires attunement' }})
           </span>


### PR DESCRIPTION
## Description

I added a null checking for the rarity properties in the `/magic-items/[id]` route

## Related Issue

Closes #741 

## How was this tested?
I edited the `magic-items/srd-2024_adamantine-armor` entry in my SQLite DB, setting 
rarity_id = NULL and loaded the page

<img width="1433" height="695" alt="image" src="https://github.com/user-attachments/assets/88c593fb-0ef8-4483-ae56-612d30ec720d" />
