### PR TITLE
Add Monster illustrations to /monsters/[id] page

### DIFF
--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -38,8 +38,9 @@
     </div>
 
     <img
-      v-if="mode !== 'compact' && monster.img_main"
-      :src="monster.img_main"
+      v-if="mode !== 'compact' && monster.illustration"
+      :src="useRuntimeConfig().public.apiUrl + monster.illustration.file_url"
+      :alt="monster.name"
       class="img-main"
     />
     <p class="italic">
@@ -87,9 +88,9 @@
       </dt>
       <dd
         class="w-min cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
-        @click="useDiceRoller(initiativeBonus, { 
+        @click="useDiceRoller(initiativeBonus, {
           title: 'Initiative',
-          subtitle: monster.name 
+          subtitle: monster.name
         })"
       >
         {{ useFormatModifier(initiativeBonus) }}


### PR DESCRIPTION
## Description

I modified the monster/[id] page to use the field illustration if it exists (also an alt attribute with the monster's name). 

## Related Issue

*Closes #739*

## How was this tested?

I checked with two monster records, one with a null illustration field and one with a valid value. 
<img width="1919" height="841" alt="image" src="https://github.com/user-attachments/assets/5a75412c-6ce6-4577-8f14-8eedbdbfc563" />


<img width="1919" height="843" alt="image" src="https://github.com/user-attachments/assets/8907903a-0925-406b-baf3-268606264e12" />


