### PR TITLE
[BUGFIX] Subspecies traits now render correctly on `/species/[id]`

### DIFF
--- a/app/pages/species/[id].vue
+++ b/app/pages/species/[id].vue
@@ -31,7 +31,7 @@
         </dd>
       </div>
     </dl>
-    <ul v-if="subspecies.length > 0">
+    <ul v-if="subspecies?.length > 0">
       <h2>Sub-species</h2>
       <li
         v-for="item in subspecies"
@@ -53,7 +53,7 @@
         />
         <dl>
           <div
-            v-for="trait in species.traits"
+            v-for="trait in item.traits"
             :key="trait.name"
             class="my-2"
           >


### PR DESCRIPTION
## Description
This PR fixes a bug on the `/species/[id]` page where subspecies would list the traits of their base species instead of their specific traits. This was due to a typo in `v-for` directive.


## Related Issue
Closes #747 

## How was this tested?
- Spot checked on local development server (pulling data from Django test server running the `staging` branch of the API)
- `npm run test` (all pass)
- `npm run build` (build process completes without error)
