### PR TITLE
Fixed Typescript auto-import errors

### DIFF
--- a/app/components/EncounterBuilder.vue
+++ b/app/components/EncounterBuilder.vue
@@ -168,14 +168,6 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
-import {
-  useEncounterStore,
-  type DifficultyLevel,
-} from '~/composables/useEncounter';
-import { usePartyStore } from '~/composables/useParty';
-import EncounterBuilderPartyBuilder from '~/components/EncounterBuilderPartyBuilder.vue';
-import EncounterBuilderMonsterSearch from '~/components/EncounterBuilderMonsterSearch.vue';
 import type { Monster } from '~/types/monster';
 
 // Prop included for testing purposes

--- a/app/components/EncounterBuilder.vue
+++ b/app/components/EncounterBuilder.vue
@@ -168,6 +168,7 @@
 </template>
 
 <script setup lang="ts">
+import EncounterBuilderMonsterSearch from '~/components/EncounterBuilderMonsterSearch.vue';
 import type { Monster } from '~/types/monster';
 
 // Prop included for testing purposes

--- a/app/components/EncounterBuilderPartyBuilder.vue
+++ b/app/components/EncounterBuilderPartyBuilder.vue
@@ -47,9 +47,6 @@
 </template>
 
 <script setup lang="ts">
-import { usePartyStore } from '~/composables/useParty';
-import { onMounted } from 'vue';
-
 const store = usePartyStore();
 const { partyRows, addPartyRow, removePartyRow }
   = store;

--- a/app/components/Modal.vue
+++ b/app/components/Modal.vue
@@ -86,7 +86,6 @@
 </template>
 
 <script setup>
-import { useSlots } from 'vue';
 import {
   Dialog,
   DialogPanel,

--- a/app/components/ModalReportIssue.vue
+++ b/app/components/ModalReportIssue.vue
@@ -17,8 +17,6 @@
 </script>
 
 <script setup>
-import { ref } from 'vue';
-
 const isOpen = ref(false);
 const formData = ref({});
 const status = ref('ready');

--- a/app/components/ResultsTableRow.vue
+++ b/app/components/ResultsTableRow.vue
@@ -51,8 +51,6 @@
 </template>
 
 <script setup>
-import SourceTag from './SourceTag.vue';
-
 defineProps({
   data: { type: Object, default: () => {} }, // Open5e data to render
   cols: { type: Array, default: () => [] }, // Arr. of table columns to render

--- a/app/composables/useFindPaginated.ts
+++ b/app/composables/useFindPaginated.ts
@@ -20,7 +20,7 @@ export const useFindPaginated = (options: {
   sortByProperty?: MaybeRef<string>;
   isSortDescending?: MaybeRef<boolean>;
   filter?: MaybeRef<Record<string, never>>;
-  params?: MaybeRef<Record<string, never>>;
+  params?: MaybeRef<Record<string, string | number | boolean>>;
 }) => {
   const {
     endpoint,

--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -339,8 +339,6 @@
 </template>
 
 <script setup lang="ts">
-import { useEncounterStore } from '~/composables/useEncounter';
-
 const route = useRoute();
 const params = {
   environments__fields: 'name',
@@ -381,7 +379,7 @@ const actions = computed(() => {
 });
 
 // Converts SNAKE_CASE to Title Case, used for action type headers
-const snakeToTitleCase = input =>
+const snakeToTitleCase = (input: string) =>
   input
     .toLowerCase()
     .split('_')

--- a/app/pages/monsters/index.vue
+++ b/app/pages/monsters/index.vue
@@ -140,10 +140,9 @@
 </template>
 
 <script setup lang="ts">
-import { h, computed } from 'vue';
+import { h } from 'vue';
 import { PlusIcon, MinusIcon } from '@heroicons/vue/24/solid';
 import type { Monster } from '~/types/monster';
-import { useEncounterStore } from '~/composables/useEncounter';
 
 // Set up filters
 const filterState = useFilterState<MonsterFilter>({

--- a/app/pages/search/index.vue
+++ b/app/pages/search/index.vue
@@ -66,8 +66,6 @@
 </template>
 
 <script setup>
-import { computed } from 'vue';
-
 const searchText = useQueryParam('text');
 const { data } = useSearch(searchText);
 const { sources } = useSourcesList();

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -96,7 +96,12 @@ export default defineNuxtConfig({
   },
 
   typescript: {
-    strict: false,
+    // typeCheck: true,
+    strict: true
+  },
+  imports: {
+    autoImport: true,
+    global: true,
   },
 
   compatibilityDate: '2024-11-16',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,31 +1,6 @@
 {
+  "extends": "./.nuxt/tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
-    "lib": ["esnext", "dom"],
-    "jsx": "preserve",
-    "baseUrl": ".",
-    "paths": {
-      "~/*": ["./app/*"],
-      "@/*": ["./app/*"]
-    },
-    "types": ["@types/node", "@nuxt/types"],
-    "esModuleInterop": true,
-    "noEmit": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true
+    "types": ["@types/node"]
   },
-  "include": [
-    "nuxt.config.ts",
-    // TODO: `vue-tsc` required to type-check .vue files (issue #714)
-    "pages/**/*.vue",
-    "layouts/default.vue",
-    "components/**/*.vue",
-    "composables/**/*.ts",
-    "plugins/**/*.ts",
-    "store/**/*.ts"
-  ],
-  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Description

This PR fixes an error on `staging` where functions, components, and composables that are auto-imported by Nuxt were being flagged as undefined by the Vue Typescript Compiler (`vue-tsc`).

The solution to this problem was to remove many of the configuration options from `tsconfig.json`, which were conflicting with and overwriting the default Nuxt/TS behaviour set up by:

```
"extends": "./.nuxt/tsconfig.json",
```

The only really consequential changes were those made to `tsconfig.json` and `nuxt.config.ts`. All the changes made to files within the `/app` directory were to fix trivial TS errors, or to remove unneeded import statements.

These changes have resolved all of the TS errors that were observed in issue #735. However, as the project composables are configured correctly with Vue TSC, a large number of new TS errors have become visible. The vast majority of these are due to our data fetching composables not being typed correctly. This will be handled in a seperate issue, and will likely leverage the API types added in PR #726.

## Related Issue

Closes #735 

## How was this tested?

- Visually inspected on Nuxt local server (pulling data from API `staging` branch)
- All tests passed (see below) `npm run test`
- Build process completes without error `npm run build`

## Following up

I can across a strange error while tidying up some of the unnecassry import statements on pages, components, and composables. Removing the `import EncounterBuilderMonsterSearch from '~/components/EncounterBuilderMonsterSearch.vue';` statement from `app/components/EncounterBuilder.vue` caused tests to fail. The other unnecassary imports removed from this file had no effect on the tests. There is likely an issue with this test and how it mocks its child components. I have left the import statement in for now, this error can be addressed in a follow up issue.

