### PR TITLE
Source Selector Improvements (sort order and sensible defaults)

### DIFF
--- a/app/components/EncounterBuilderMonsterSearch.vue
+++ b/app/components/EncounterBuilderMonsterSearch.vue
@@ -81,9 +81,6 @@ import {
   ComboboxOptions,
   ComboboxOption,
 } from '@headlessui/vue';
-import { ref, watchEffect } from 'vue';
-import { useAPI, API_ENDPOINTS } from '~/composables/api';
-import { useSourcesList } from '~/composables/sources';
 import type { Monster } from '~/types/monster';
 import type { RawMonster } from '~/types/APIMonster';
 const emit = defineEmits<{

--- a/app/components/ModalSourceSelector.vue
+++ b/app/components/ModalSourceSelector.vue
@@ -168,6 +168,8 @@
 </template>
 
 <script setup>
+import { sortDocumentsByPublisher } from '~/functions/sortDocumentsByPublisher';
+
 
 // fetch full list of document sources
 const { data: documents } = useDocuments({
@@ -190,18 +192,13 @@ const documentsInSystem = computed(() => {
   });
 });
 
-// TODO: PR #728 introduces a `sortDocumentsByPublisher` util function. Replace
-// the code below with that once #728 is merged to the `staging` branch
-
 // group filtered documents by publisher
 const groupedDocuments = computed(() => {
-  const docs = documentsInSystem.value ?? [];
-  return docs.reduce((grouped, document) => {
-    const publisher = document.publisher.name;
-    if (grouped[publisher]) grouped[publisher].push(document);
-    else grouped[publisher] = [document];
-    return grouped;
-  }, {});
+  const sortedDocuments = sortDocumentsByPublisher(documentsInSystem);
+
+  // Bring WotC sources to the top of the publisher list
+  const { ['Wizards of the Coast']: value, ...rest } = sortedDocuments;
+  return { ['Wizards of the Coast']: value, ...rest};
 });
 
 // state for current game system

--- a/app/composables/api.ts
+++ b/app/composables/api.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { navigateTo, useRoute, useRuntimeConfig } from 'nuxt/app';
 import type { MaybeRef, Ref } from 'vue';
 import { computed, unref } from 'vue';
-import { useSourcesList } from './sources';
+import { useSourcesList } from './useSourcesList';
 import type { components } from '~/types/open5e-api';
 
 // Extract schemas from OpenAPI components

--- a/app/composables/useSourcesList.ts
+++ b/app/composables/useSourcesList.ts
@@ -1,9 +1,9 @@
 import { computed, ref } from 'vue';
 
-function loadSourcesFromLocalStorage() {
+function loadSourcesFromLocalStorage(): string[] {
   if (!import.meta.client) return []; // skip on server
   const saved_sources = localStorage.getItem('sources');
-  return saved_sources ? JSON.parse(saved_sources) : [];
+  return saved_sources ? JSON.parse(saved_sources) : ['srd-2014', 'srd-2024'];
 }
 
 function writeSourcesToLocalStorage(sourcesList: string[]) {
@@ -27,31 +27,6 @@ const setGameSystem = (input: string) => {
   writeGameSystenToStorage(input);
 };
 
-/* _sourcesV1 maps Document keys from API V2 onto their V1 equivalents. This
- * has been added so that we can move the /documents endpoint over to V2 w/o
- * breaking the seleciton by source functionality for routes pulling from V1.
- * Keys omitted from the sourcemap will be the same for V1 & V2 endpoints */
-
-const _sourcesV1 = computed(() => {
-  if (!_sources.value || _sources.value.length === 0) return [];
-  const sourcemap: { [key: string]: string } = {
-    'a5e-ag': 'a5e',
-    'bfrd': 'blackflag',
-    'ccdx': 'cc',
-    'deepm': 'dmag',
-    'deepmx': 'dmag-e',
-    'mmenag': 'menagerie',
-    'open5e': 'o5e',
-    'srd': 'wotc-srd',
-    'tdcs': 'taldorei',
-    'wz': 'warlock',
-  };
-  return _sources.value.map((source) => {
-    if (source in sourcemap) return sourcemap[source];
-    return source;
-  });
-});
-
 // Overwrite all sources, update local storage
 export const setSources = (sources: string[]) => {
   _sources.value = sources;
@@ -67,5 +42,4 @@ export const useSourcesList = () => ({
   gameSystem,
   setGameSystem,
   setSources,
-  sourcesAPIVersion1: _sourcesV1,
 });


### PR DESCRIPTION
## Build Preview
https://deploy-preview-755--open5e-preview.netlify.app/

## Description

This PR address the following problems with the Source Selector, as outlined in the linked issue:

- The Source Selector is now loaded with sensible defaults. When a user first visits the site the WotC SRD 5.1 and 5.2 are the only sources that are selected.
- In the Source's list UI the WotC published materials have been moved to the top of the list of sources

<img width="932" height="678" alt="Screenshot 2025-09-04 at 10 24 55" src="https://github.com/user-attachments/assets/fcfa705d-c0bf-4bb4-a185-6fe91835d653" />


## Related Issue

Closes #754 

## How was this tested?

- Spot checked on local Nuxt development server (`npm run dev`) pulling data from the `staging` branch of the Open5e API, running on a local Django test server
- `npm run test` (All passing)
- `npm run build` (Build process completes without error)