### PR TITLE
Fixed bug with Sortable Table Header

### DIFF
--- a/app/components/ResultsTable.vue
+++ b/app/components/ResultsTable.vue
@@ -98,6 +98,6 @@ withDefaults(defineProps<ResultsTableProps<T>>(), {
 const emit = defineEmits(['sort']);
 
 const onSort = (sortValue?: string) => {
-  if (!sortValue) emit('sort', sortValue);
+  if (sortValue) emit('sort', sortValue);
 };
 </script>


### PR DESCRIPTION
## Build Preview
https://deploy-preview-757--open5e-preview.netlify.app/

## Description

This error fixes a bug where the `<SortableTableHeader>` component was not sorting the API results on the O5e top-level pages when clicked.

The problem turned out to be in the `<ResultsTable>` component, which had a logical error in a guard-clause in the handler function for when the `<SortableTableHeader>` component emitted the `"sort"` message, which meant that this emit wasn't getting hot-potatoed up to the page component that was actually fetching the data

## Related Issue

Closes #756 

## How was this tested?

- Spot checked using the Nuxt development server (pulling data from the `staging` branch of the API)
- `npm run test` (all tests passing)
- `npm run build` (build process completes without error)