### PR TITLE
[BUGFIX / TYPESCRIPT] Refactor `useFormatModifier` and `useDiceRoller` composables

### DIFF
--- a/app/components/InlineRoller.global.vue
+++ b/app/components/InlineRoller.global.vue
@@ -28,5 +28,5 @@ defineProps({
   signature: { type: String, default: '' },
 });
 
-const { rollDice } = useDiceRoller();
+const rollDice = useDiceRoller();
 </script>

--- a/app/components/InlineRoller.global.vue
+++ b/app/components/InlineRoller.global.vue
@@ -17,7 +17,7 @@
 <template>
   <span
     class="cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
-    @click="useDiceRoller(signature)"
+    @click="rollDice(signature)"
   >
     <slot />
   </span>
@@ -27,4 +27,6 @@
 defineProps({
   signature: { type: String, default: '' },
 });
+
+const { rollDice } = useDiceRoller();
 </script>

--- a/app/components/MonsterAbilities.vue
+++ b/app/components/MonsterAbilities.vue
@@ -108,8 +108,8 @@
 </template>
 
 <script lang="ts" setup>
-const { rollDice } = useDiceRoller();
-const { formatModifier } = useFormatModifier();
+const rollDice = useDiceRoller();
+const formatModifier = useFormatModifier();
 
 const props = defineProps({
   monster: { type: Object, default: () => {} },

--- a/app/components/MonsterAbilities.vue
+++ b/app/components/MonsterAbilities.vue
@@ -90,7 +90,7 @@
               subtitle: monster.name,
             })"
           >
-            {{ useFormatModifier(data.mod) }}
+            {{ formatModifier(data.mod) }}
           </td>
           <td
             :class="rollableLinkClasses"
@@ -99,7 +99,7 @@
               subtitle: monster.name,
             })"
           >
-            {{ useFormatModifier(data.save) }}
+            {{ formatModifier(data.save) }}
           </td>
         </tr>
       </tbody>
@@ -108,9 +108,8 @@
 </template>
 
 <script lang="ts" setup>
-import { useFormatModifier } from '@/composables/useFormatModifier';
-
 const { rollDice } = useDiceRoller();
+const { formatModifier } = useFormatModifier();
 
 const props = defineProps({
   monster: { type: Object, default: () => {} },

--- a/app/components/MonsterAbilities.vue
+++ b/app/components/MonsterAbilities.vue
@@ -85,7 +85,7 @@
           </td>
           <td
             :class="rollableLinkClasses"
-            @click="useDiceRoller(data.mod, {
+            @click="rollDice(data.mod, {
               title: `${ability} Check`,
               subtitle: monster.name,
             })"
@@ -94,7 +94,7 @@
           </td>
           <td
             :class="rollableLinkClasses"
-            @click="useDiceRoller(data.save, {
+            @click="rollDice(data.save, {
               title: `${ability} Save`,
               subtitle: monster.name,
             })"
@@ -109,7 +109,8 @@
 
 <script lang="ts" setup>
 import { useFormatModifier } from '@/composables/useFormatModifier';
-import { useDiceRoller } from '@/composables/useDiceRoller';
+
+const { rollDice } = useDiceRoller();
 
 const props = defineProps({
   monster: { type: Object, default: () => {} },

--- a/app/composables/monsters.ts
+++ b/app/composables/monsters.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/vue-query';
 import { API_ENDPOINTS, useAPI } from './api';
 
-const { formatModifier } = useFormatModifier();
+const formatModifier = useFormatModifier();
 
 export type MonsterFilter = {
   name__icontains?: string; // filter by name (TODO)

--- a/app/composables/monsters.ts
+++ b/app/composables/monsters.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/vue-query';
 import { API_ENDPOINTS, useAPI } from './api';
-import { useFormatModifier } from './useFormatModifier';
+
+const { formatModifier } = useFormatModifier();
 
 export type MonsterFilter = {
   name__icontains?: string; // filter by name (TODO)
@@ -29,7 +30,7 @@ export const useMonster = (slug: string) => {
         name: ability,
         shortName: ability.slice(0, 3),
         score: monster[ability],
-        modifier: useFormatModifier(
+        modifier: formatModifier(
           monster[ability] as string | number | undefined,
           { inputType: 'score' },
         ),

--- a/app/composables/useDiceRoller.ts
+++ b/app/composables/useDiceRoller.ts
@@ -1,7 +1,8 @@
-import { useFormatModifier } from './useFormatModifier';
 import { useNotifications } from './useNotifications';
 
 const { addNotif } = useNotifications();
+
+const { formatModifier } = useFormatModifier();
 
 type UseDiceRollerOptions = {
   title?: string;
@@ -33,7 +34,7 @@ export function useDiceRoller() {
     const result = rolls.reduce((total, roll) => total + roll) + modifier;
 
 
-    const formattedModifier = useFormatModifier(modifier, {
+    const formattedModifier = formatModifier(modifier, {
       showZero: false,
       spaceAfterOrdinal: true,
     });

--- a/app/composables/useDiceRoller.ts
+++ b/app/composables/useDiceRoller.ts
@@ -2,7 +2,7 @@ import { useNotifications } from './useNotifications';
 
 const { addNotif } = useNotifications();
 
-const { formatModifier } = useFormatModifier();
+const formatModifier = useFormatModifier();
 
 type UseDiceRollerOptions = {
   title?: string;
@@ -79,5 +79,5 @@ export function useDiceRoller() {
     }
   };
   
-  return { rollDice };
+  return rollDice;
 }

--- a/app/composables/useDiceRoller.ts
+++ b/app/composables/useDiceRoller.ts
@@ -8,71 +8,75 @@ type UseDiceRollerOptions = {
   subtitle?: string;
 }
 
-export function useDiceRoller(
-  input: string | number,
-  options: UseDiceRollerOptions,
-) {
-  // make sure dice signature is a string
-  const signature = typeof input === 'string' ? input : input.toString();
+export function useDiceRoller() {
+  const rollDice = (
+    input: string | number,
+    options: UseDiceRollerOptions,
+  ) => {
+    // make sure dice signature is a string
+    const signature = typeof input === 'string' ? input : input.toString();
 
-  // extract numerical data from dice signature
-  const parsed = parseDice(signature);
+    // extract numerical data from dice signature
+    const parsed = parseDice(signature);
 
-  // make sure parseDice rtn'd data before deconstructing arr.
-  if (!parsed) return;
+    // make sure parseDice rtn'd data before deconstructing arr.
+    if (!parsed) return;
 
-  const [number, dice, modifier] = parsed;
+    const [number, dice, modifier] = parsed;
 
-  // roll the dice
-  const rolls = [...Array(number)].map(
-    () => Math.floor(Math.random() * dice) + 1,
-  );
+    // roll the dice
+    const rolls = [...Array(number)].map(
+      () => Math.floor(Math.random() * dice) + 1,
+    );
 
-  // add up the results and add the modifier
-  const result = rolls.reduce((total, roll) => total + roll) + modifier;
+    // add up the results and add the modifier
+    const result = rolls.reduce((total, roll) => total + roll) + modifier;
 
 
-  const formattedModifier = useFormatModifier(modifier, {
-    showZero: false,
-    spaceAfterOrdinal: true,
-  });
+    const formattedModifier = useFormatModifier(modifier, {
+      showZero: false,
+      spaceAfterOrdinal: true,
+    });
 
-  const formattedDiceSignature = `${number}d${dice} ${formattedModifier}`;
+    const formattedDiceSignature = `${number}d${dice} ${formattedModifier}`;
 
-  const notifTitle = options?.title 
-    ? `${options.title}`
-    : `Rolling ${formattedDiceSignature}`;
+    const notifTitle = options?.title 
+      ? `${options.title}`
+      : `Rolling ${formattedDiceSignature}`;
+    
+    // push results to notifications
+    addNotif({
+      title: notifTitle,
+      subtitle: options?.subtitle ?? '',
+      body: result,
+      footer: `[ ${rolls.join(', ')} ] ${formattedModifier}`,
+    });
+
+    return { signature, rolls, result };
+  };
+
+  function parseDice(input: string) {
+    const pattern = /(\d*)[dD](\d+)\s*([+-]\s*\d+)?|^([+-]?\d+)\s*(?: to hit)?$/;
+
+    // groups 1-3 handle values in full dice sig. ie. 1d20+4, group 4 captures solo mod ie. +5
+    const matches = input.match(pattern);
+
+    if (!matches) return;
+
+    // groups 1-3 capture num/size/mod from dice sigs. in the form 1d20+4
+    if (matches[2]) {
+      const number = parseInt(matches[1] ?? 1);
+      const size = parseInt(matches[2] ?? 20);
+      const modifier = matches[3] ? parseInt(matches[3].split(' ').join('')) : 0;
+      return [number, size, modifier];
+    }
+
+    // group 4 captures the modifier from +5 or +3 to hit
+    if (matches[4]) {
+      const modifier = parseInt(matches[4]);
+      return [1, 20, modifier];
+    }
+  };
   
-  // push results to notifications
-  addNotif({
-    title: notifTitle,
-    subtitle: options?.subtitle ?? '',
-    body: result,
-    footer: `[ ${rolls.join(', ')} ] ${formattedModifier}`,
-  });
-
-  return { signature, rolls, result };
-}
-
-function parseDice(input: string) {
-  const pattern = /(\d*)[dD](\d+)\s*([+-]\s*\d+)?|^([+-]?\d+)\s*(?: to hit)?$/;
-
-  // groups 1-3 handle values in full dice sig. ie. 1d20+4, group 4 captures solo mod ie. +5
-  const matches = input.match(pattern);
-
-  if (!matches) return;
-
-  // groups 1-3 capture num/size/mod from dice sigs. in the form 1d20+4
-  if (matches[2]) {
-    const number = parseInt(matches[1] ?? 1);
-    const size = parseInt(matches[2] ?? 20);
-    const modifier = matches[3] ? parseInt(matches[3].split(' ').join('')) : 0;
-    return [number, size, modifier];
-  }
-
-  // group 4 captures the modifier from +5 or +3 to hit
-  if (matches[4]) {
-    const modifier = parseInt(matches[4]);
-    return [1, 20, modifier];
-  }
+  return { rollDice };
 }

--- a/app/composables/useFormatModifier.ts
+++ b/app/composables/useFormatModifier.ts
@@ -32,5 +32,5 @@ export const useFormatModifier = () => {
       ); 
     };
     
-  return { formatModifier };
+  return formatModifier;
 };

--- a/app/composables/useFormatModifier.ts
+++ b/app/composables/useFormatModifier.ts
@@ -1,31 +1,36 @@
 /* useFormatModifier generates a formatted modifier from either a numerical
  * modifier or an ability score. */
 
-export const useFormatModifier = (
-  input: string | number | undefined,
-  options?: {
-    inputType?: 'modifier' | 'score';
-    showZero?: boolean;
-    spaceAfterOrdinal?: boolean;
-  },
-) => {
-  if (input === undefined) return '-';
+export const useFormatModifier = () => {
+  const formatModifier = (
+    input: string | number | undefined,
+      options?: {
+        inputType?: 'modifier' | 'score';
+        showZero?: boolean;
+        spaceAfterOrdinal?: boolean;
+      }
+    ) => {
+      if (input === undefined) return '-';
 
-  // set options defaults
-  const type = options?.inputType ?? 'modifer';
-  const showZero = options?.showZero ?? true;
+      // set options defaults
+      const type = options?.inputType ?? 'modifer';
+      const showZero = options?.showZero ?? true;
 
-  // cast input to number
-  const inputNum = typeof input === 'string' ? parseInt(input) : input;
+      // cast input to number
+      const inputNum = typeof input === 'string' ? parseInt(input) : input;
 
-  // handle 0s if showZero option is false
-  if (inputNum === 0 && !showZero) return '';
+      // handle 0s if showZero option is false
+      if (inputNum === 0 && !showZero) return '';
 
-  // convert score to mod
-  const mod = type === 'score' ? Math.floor((inputNum - 10) / 2) : inputNum;
+      // convert score to mod
+      const mod = type === 'score' ? Math.floor((inputNum - 10) / 2) : inputNum;
 
-  return (
-    (mod < 0 ? '-' : '+') // generate ordinal
-    + (options?.spaceAfterOrdinal ? ' ' : '') // add space before ordinal
-    + mod.toString().replace('-', '')); // rmv '-' from stringified mod
+      return (
+        (mod < 0 ? '-' : '+') // generate ordinal
+        + (options?.spaceAfterOrdinal ? ' ' : '') // add space before ordinal
+        + mod.toString().replace('-', '') // rmv '-' from stringified mod
+      ); 
+    };
+    
+  return { formatModifier };
 };

--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -318,8 +318,8 @@
 </template>
 
 <script setup lang="ts">
-const { rollDice } = useDiceRoller();
-const { formatModifier } = useFormatModifier();
+const rollDice = useDiceRoller();
+const formatModifier = useFormatModifier();
 
 const params = {
   environments__fields: 'name',

--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -78,7 +78,7 @@
       </dt>
       <dd
         class="w-min cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
-        @click="useDiceRoller(initiativeBonus, {
+        @click="rollDice(initiativeBonus, {
           title: 'Initiative',
           subtitle: monster.name
         })"
@@ -95,7 +95,7 @@
         <span
           v-if="monster.hit_dice"
           class="cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
-          @click="useDiceRoller(monster.hit_dice, {
+          @click="rollDice(monster.hit_dice, {
              title: 'Hit Points',
              subtitle: monster.name
           })"
@@ -143,7 +143,7 @@
           v-for="(modifier, skill) in monster.skill_bonuses"
           :key="skill"
           class="inline cursor-pointer font-bold capitalize text-blood after:text-black after:content-[',_'] last:after:content-[] hover:text-black dark:after:text-white dark:hover:text-fog"
-          @click="useDiceRoller(modifier.toString(), {
+          @click="rollDice(modifier.toString(), {
              title: skill,
              subtitle: monster.name
           })"
@@ -265,7 +265,7 @@
           <span
             v-if="action.uses_type === 'RECHARGE_ON_ROLL'"
             class="cursor-pointer font-bold text-blood before:text-black before:content-['_('] after:text-black after:content-[')_'] hover:text-black dark:before:text-white dark:after:text-white dark:hover:text-white"
-            @click="useDiceRoller('1d6+0', {
+            @click="rollDice('1d6+0', {
               title: `${action.name} Recharge`,
               subtitle: monster.name,
             })"
@@ -318,7 +318,7 @@
 </template>
 
 <script setup lang="ts">
-import { useEncounterStore } from '~/composables/useEncounter';
+const { rollDice } = useDiceRoller();
 
 const params = {
   environments__fields: 'name',

--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -83,7 +83,7 @@
           subtitle: monster.name
         })"
       >
-        {{ useFormatModifier(initiativeBonus) }}
+        {{ formatModifier(initiativeBonus) }}
       </dd>
 
       <!-- HIT POINTS -->
@@ -148,7 +148,7 @@
              subtitle: monster.name
           })"
         >
-          {{ `${skill} ${useFormatModifier(modifier)}` }}
+          {{ `${skill} ${formatModifier(modifier)}` }}
         </li>
       </ul>
 
@@ -319,6 +319,7 @@
 
 <script setup lang="ts">
 const { rollDice } = useDiceRoller();
+const { formatModifier } = useFormatModifier();
 
 const params = {
   environments__fields: 'name',


### PR DESCRIPTION
## Description

This PR refactors the `useFormatModifier()` and `useDiceRoller()` composables so that they return an object containing a function which performs that composables function. The purpose of this change was so avoid the composable being called directly in the `<template>` tag, which is goes against Nuxt best practices and also throws up a heap of Typescript errors

## Related Issue

Closes #758

## How was this tested?
- Spot checking on the Nuxt development server (pulling data from the `staging` branch of the API)
- `npm run test` (all tests passing)
- `npm run build` (build process completes without error)

## Build Preview
https://deploy-preview-759--open5e-preview.netlify.app/