### PR TITLE
fix: source selector modals getting out of sync

### DIFF
--- a/app/components/ModalSourceSelector.vue
+++ b/app/components/ModalSourceSelector.vue
@@ -177,9 +177,12 @@ const { data: documents } = useDocuments({
 });
 
 const { sources, setSources, gameSystem, setGameSystem } = useSourcesList();
-const selectedSources = ref(sources.value);
+const selectedSources = ref([]);
 const emit = defineEmits(['close']);
 const closeModal = () => emit('close');
+
+// Keep selectedSources in sync with global sources state
+watchEffect(() => selectedSources.value = [...sources.value]);
 
 // filter documents by the current game system
 const documentsInSystem = computed(() => {
@@ -205,7 +208,10 @@ const groupedDocuments = computed(() => {
 });
 
 // state for current game system
-const currentSystem = ref(gameSystem.value);
+const currentSystem = ref('');
+
+// Keep currentSystem in sync with global gameSystem state
+watchEffect(() => currentSystem.value = gameSystem.value);
 
 // returns the names of all game systems present in API data
 const allGameSystems = computed(() => {


### PR DESCRIPTION
## Description
This PR resolves an issue where the source select modals were getting out of sync.

## Related Issue
Closes #762

## How was this tested?
Since there were no existing automated tests covering this bug, I verified the fix manually:
• Reproduced the issue by following the same steps shown in the video attached to the GitHub issue.
• Confirmed the bug is resolved after applying the fix.
• Ran npm run build to ensure the build process completed successfully without errors.
• Ran npm run test to confirm that all existing tests still pass.

