### PR TITLE
[BUGFIX] Updated Conditions single-view page to work with updated API reponse

### DIFF
--- a/app/pages/conditions/[id].vue
+++ b/app/pages/conditions/[id].vue
@@ -11,7 +11,30 @@
         :title="condition.document.name"
       />
     </h1>
-    <md-viewer :text="condition.desc" />
+
+    <!-- Display condition descriptions as a list if API rtns more than one -->
+    <div v-if="condition.descriptions.length > 1">
+      <p class="my-4 italic">
+        <span>The </span>
+        <span class="font-bold">{{ condition.name }}</span>
+        <span> condition has multiple definitions in different rulebooks.</span>
+      </p>
+      <dl class="grid gap-6">
+        <div v-for="description in condition.descriptions" :key="description.document">
+          <dt class="text-xl font-bold text-granite">
+            {{ description.gamesystem }}
+          </dt>
+          <dd class="mt-0">
+            <MdViewer :text="description.desc"/>
+          </dd>
+        </div>
+      </dl>
+    </div>
+
+    <!-- Display conditions with a single description as they are -->
+    <v-else>
+      <MdViewer :text="condition.descriptions[0].desc" />
+    </v-else>
   </section>
 </template>
 
@@ -19,7 +42,12 @@
 const { data: condition } = useFindOne(
   API_ENDPOINTS.conditions,
   useRoute().params.id,
-  { params: { fields: ['name', 'desc', 'document'].join(',') } },
+  { 
+    params: { 
+      fields: ['name', 'descriptions', 'document'].join(','),
+      document__fields: ['key', 'display_name'].join(',')
+    } 
+  },
 );
 
 // generate source key from page URL - for use with source-tab cmpnt

--- a/tests/unit/pages/condition.test.tsx
+++ b/tests/unit/pages/condition.test.tsx
@@ -20,7 +20,23 @@ mockNuxtImport('useFindOne', () => {
   return () => ({
     data: {
       name: 'Blinded',
-      desc: '* A blinded creature can\'t see and automatically fails any ability check that requires sight.\r\n* Attack rolls against the creature have advantage, and the creature’s attack rolls have disadvantage.',
+      "descriptions": [
+        {
+            "desc": "* A blinded creature can’t see and it automatically fails ability checks that require sight.\n\n* Attack rolls against a blinded creature are made with advantage, and the creature’s attack rolls are made with disadvantage.",
+            "document": "a5e-ag",
+            "gamesystem": "a5e"
+        },
+        {
+            "desc": "* A blinded creature can't see and automatically fails any ability check that requires sight.\r\n* Attack rolls against the creature have advantage, and the creature’s attack rolls have disadvantage.",
+            "document": "srd-2014",
+            "gamesystem": "5e-2014"
+        },
+        {
+            "desc": "While you have the Blinded condition, you experience the following effects.\n * Can’t See. You can’t see and automatically fail any ability check that requires sight.\n * Attacks Affected. Attack rolls against you have Advantage, and your attack rolls have Disadvantage.",
+            "document": "srd-2024",
+            "gamesystem": "5e-2024"
+        }
+      ],
       document: {
         name: 'Systems Reference Document',
         url: 'v2/documents/srd/',


### PR DESCRIPTION
## Build Preview
https://deploy-preview-767--open5e-preview.netlify.app/

## Description

This PR fixes a bug introduced by upcoming breaking changes to the `/v2/conditions` endpoint in the API repository (https://github.com/open5e/open5e-api/pull/794).

The `/conditions/[id]` page now correctly parses the new condition descriptions format.

Tests needed to be updated to account for the changes in the shape of the API response
