### PR TITLE
[BUGFIX] Hits points on `/classes/[id]` now render correctly

### DIFF
--- a/app/pages/classes/[className]/index.vue
+++ b/app/pages/classes/[className]/index.vue
@@ -10,7 +10,7 @@
 
       <div v-if="hitPoints.length > 0">
         <h3>Hit Points</h3>
-        <dl>
+        <dl class="mt-4">
           <div
             v-for="item in hitPoints"
             :key="item.title"
@@ -107,7 +107,7 @@ const { data: classData } = useFindOne(
   {
     params: {
       is_subclass: false,
-      fields: ['name', 'key', 'subclasses', 'features'].join(),
+      fields: ['name', 'key', 'subclasses', 'features', 'hit_points'].join(),
     },
   },
 );


### PR DESCRIPTION
## Description

This PR fixes a bug on the `/classes/[id]` page where hit point information about classes was not being rendered. Code existed in the page template for rendering this information, but the problem was that the `'hit_points'` field returned by the `/v2/classes` API endpoint was not included in the `fields` query parameter, which controls which fields the API should return. Adding this in fixed the problem.

I also noticed that the space between the title of the Hit Points and its body was much smaller than on other section of the same page. I added a margin so that it conforms to the existing page structure

<img width="857" height="724" alt="Screenshot 2025-09-23 at 09 08 30" src="https://github.com/user-attachments/assets/12bba2ef-6439-4512-9d5c-808a182afe59" />

## Related Issue

Closes #768

## How was this tested?

- Spot checking on local Nuxt development server (pulling data from `staging` branch of API, running on a local Django test server)
- Ran `npm run test` to make sure all tests were still passing
- Ran `npm run build` to ensure that the build process still completed without error