### PR TITLE
[BUGFIXES] Updating single-view Class/Subclass pages to work with latest API updates

### DIFF
--- a/app/components/ClassTable.vue
+++ b/app/components/ClassTable.vue
@@ -45,6 +45,7 @@
         <th
           v-if="spellslotColumnHeaders"
           :colspan="spellslotColumnHeaders.length"
+          class="text-center"
         >
           Spell Slots by Level
         </th>
@@ -96,6 +97,7 @@
       <td
         v-for="column in additionalColumnHeaders"
         :key="column"
+        class="text-center"
       >
         {{ classResourceTableData[column][level] ?? '-' }}
       </td>
@@ -103,6 +105,7 @@
       <td
         v-for="spellLevel in spellslotColumnHeaders"
         :key="spellLevel"
+        class="text-center"
       >
         {{ getSpellSlots(level, spellLevel) }}
       </td>

--- a/app/pages/classes/[className]/[subclass].vue
+++ b/app/pages/classes/[className]/[subclass].vue
@@ -11,7 +11,13 @@
           v-for="feature in features"
           :key="feature.key"
         >
-          <h3>{{ feature.name }}</h3>
+        
+          <h3>
+            <span v-if="feature.gained_at.length > 0">
+              {{ `Level ${feature.gained_at[0].level}: `  }}
+            </span>
+            <span>{{ feature.name }}</span>
+          </h3>
           <md-viewer
             :text="feature.desc"
             :header-level="3"

--- a/app/pages/classes/[className]/[subclass].vue
+++ b/app/pages/classes/[className]/[subclass].vue
@@ -13,7 +13,7 @@
         >
         
           <h3>
-            <span v-if="feature.gained_at.length > 0">
+            <span v-if="feature.gained_at.length > 0" class="text-granite">
               {{ `Level ${feature.gained_at[0].level}: `  }}
             </span>
             <span>{{ feature.name }}</span>

--- a/app/pages/classes/[className]/[subclass].vue
+++ b/app/pages/classes/[className]/[subclass].vue
@@ -6,6 +6,8 @@
     <h1>{{ subclassData.name }}</h1>
     <!-- CLASS ABILITIES -->
     <section>
+      <MdViewer v-if="subclassData.desc" :text="subclassData.desc"/>
+
       <ul v-if="features.length > 0">
         <li
           v-for="feature in features"
@@ -40,7 +42,7 @@ const { data: subclassData } = useFindOne(
     params: {
       is_subclass: true,
       subclass_of: useRoute().params.className,
-      fields: ['name', 'key', 'features'].join(','),
+      fields: ['name', 'desc', 'key', 'features'].join(','),
     },
   },
 );

--- a/app/pages/classes/[className]/index.vue
+++ b/app/pages/classes/[className]/index.vue
@@ -6,7 +6,8 @@
     <h1>{{ classData.name }}</h1>
     <section>
       <h2>Class Features</h2>
-      <p>As a {{ classData.name }} you gain the following features.</p>
+
+      <MdViewer v-if="classData.desc" :text="classData.desc"/>
 
       <div v-if="features.coreTraitsTable" class="mt-4">
         <label class="font-bold">{{ `Core ${classData.name} Traits` }}</label>
@@ -109,6 +110,7 @@
 </template>
 
 <script setup>
+import MdViewer from '~/components/MdViewer.vue';
 import { titleCaseToKebabCase } from '~/functions/titleCaseToKebabCase';
 
 const { data: classData } = useFindOne(
@@ -117,7 +119,14 @@ const { data: classData } = useFindOne(
   {
     params: {
       is_subclass: false,
-      fields: ['name', 'key', 'subclasses', 'features', 'hit_points'].join(),
+      fields: [
+        'desc',
+        'features',
+        'hit_points',
+        'key',
+        'name',
+        'subclasses',
+      ].join(),
     },
   },
 );

--- a/app/pages/classes/[className]/index.vue
+++ b/app/pages/classes/[className]/index.vue
@@ -83,8 +83,13 @@
           :id="titleCaseToKebabCase(feature.name)"
           :key="feature.key"
         >
-          <h3>{{ feature.name }}</h3>
-          <md-viewer
+          <h3>
+            <span v-if="feature.gained_at.length > 0">
+              {{ `Level ${findFeatureLowestLevel(feature)}: `  }}
+            </span>
+            <span>{{ feature.name }}</span>
+          </h3>
+          <MdViewer
             :text="feature.desc"
             :header-level="3"
           />

--- a/app/pages/classes/[className]/index.vue
+++ b/app/pages/classes/[className]/index.vue
@@ -107,7 +107,7 @@ const { data: classData } = useFindOne(
   {
     params: {
       is_subclass: false,
-      fields: ['name', 'key', 'subclasses', 'features'].join(),
+      fields: ['name', 'key', 'subclasses', 'features', 'hit_points'].join(),
     },
   },
 );
@@ -124,12 +124,13 @@ const features = computed(() => {
   if (!featureData) return {};
   return featureData.reduce(
     (acc, feature) => {
+      if (!feature) return acc;
       const { feature_type: type } = feature;
       if (type === 'PROFICIENCY_BONUS') acc.proficiencyBonuses = feature;
       else if (type === 'SPELL_SLOTS') acc.spellSlots.push(feature);
       else if (feature.data_for_class_table.length > 0)
         acc.classTableColumnData.push(feature);
-      else if (type === 'CLASS_FEATURE') acc.classFeatures.push(feature);
+      else if (type === 'CLASS_LEVEL_FEATURE') acc.classFeatures.push(feature);
       else if (type === 'PROFICIENCIES') acc.proficiencies.push(feature);
       else if (type === 'STARTING_EQUIPMENT')
         acc.startingEquipment.push(feature);

--- a/app/pages/classes/[className]/index.vue
+++ b/app/pages/classes/[className]/index.vue
@@ -8,7 +8,12 @@
       <h2>Class Features</h2>
       <p>As a {{ classData.name }} you gain the following features.</p>
 
-      <div v-if="hitPoints.length > 0">
+      <div v-if="features.coreTraitsTable" class="mt-4">
+        <label class="font-bold">{{ `Core ${classData.name} Traits` }}</label>
+        <MdViewer :text="features.coreTraitsTable.desc" />
+      </div>
+
+      <div v-if="!features.coreTraitsTable && hitPoints.length > 0">
         <h3>Hit Points</h3>
         <dl>
           <div
@@ -84,7 +89,7 @@
           :key="feature.key"
         >
           <h3>
-            <span v-if="feature.gained_at.length > 0">
+            <span v-if="feature.gained_at.length > 0" class="text-granite">
               {{ `Level ${findFeatureLowestLevel(feature)}: `  }}
             </span>
             <span>{{ feature.name }}</span>
@@ -132,6 +137,7 @@ const features = computed(() => {
       if (!feature) return acc;
       const { feature_type: type } = feature;
       if (type === 'PROFICIENCY_BONUS') acc.proficiencyBonuses = feature;
+      else if (type === 'CORE_TRAITS_TABLE') acc.coreTraitsTable = feature;
       else if (type === 'SPELL_SLOTS') acc.spellSlots.push(feature);
       else if (feature.data_for_class_table.length > 0)
         acc.classTableColumnData.push(feature);
@@ -143,6 +149,7 @@ const features = computed(() => {
     },
     {
       classFeatures: [],
+      coreTraitsTable: undefined,
       proficiencies: [],
       proficiencyBonuses: undefined,
       startingEquipment: [],

--- a/app/pages/classes/[className]/index.vue
+++ b/app/pages/classes/[className]/index.vue
@@ -81,7 +81,7 @@
       />
     </section>
 
-    <!-- Class Abilities -->
+    <!-- Class abilities per level -->
     <section>
       <ul v-if="featuresInOrder.length > 0">
         <li
@@ -102,6 +102,15 @@
         </li>
       </ul>
     </section>
+
+    <!-- Class ability option lists -->
+    <section v-if="features.classOptionLists?.length > 0">
+      <template v-for="feature in features.classOptionLists" :key="feature.name">
+        <h2>{{ feature.name }}</h2>
+        <MdViewer :text="feature.desc" :header-level="1" />
+      </template>
+    </section>
+
   </main>
 
   <p v-else>
@@ -154,16 +163,19 @@ const features = computed(() => {
       else if (type === 'PROFICIENCIES') acc.proficiencies.push(feature);
       else if (type === 'STARTING_EQUIPMENT')
         acc.startingEquipment.push(feature);
+      else if (type === 'CLASS_FEATURE_OPTION_LIST')
+        acc.classOptionLists.push(feature);
       return acc;
     },
     {
       classFeatures: [],
+      classTableColumnData: [],
+      classOptionLists: [],
       coreTraitsTable: undefined,
       proficiencies: [],
       proficiencyBonuses: undefined,
-      startingEquipment: [],
       spellSlots: [],
-      classTableColumnData: [],
+      startingEquipment: [],
     },
   );
 });

--- a/tests/unit/pages/class.test.tsx
+++ b/tests/unit/pages/class.test.tsx
@@ -5,18 +5,6 @@ import ClassPage from '~/pages/classes/[className]/index.vue';
 
 const { data: className } = useFindOne(API_ENDPOINTS.classes, 'srd_barbarian');
 
-const page = await mountSuspended(ClassPage);
-
-test('/classes/[className] page can mount', async () => {
-  expect(page);
-});
-
-test('/classes/[className] page renders title', async () => {
-  const title = page.find('h1');
-  expect(title.exists()).toBe(true);
-  expect(title.text()).toEqual(unref(className)?.name);
-});
-
 mockNuxtImport('useFindOne', () => {
   return () => ({
     data: {
@@ -41,81 +29,13 @@ mockNuxtImport('useFindOne', () => {
               column_value: '+2',
             },
             {
-              level: 10,
-              column_value: '+4',
-            },
-            {
-              level: 11,
-              column_value: '+4',
-            },
-            {
-              level: 12,
-              column_value: '+4',
-            },
-            {
-              level: 13,
-              column_value: '+5',
-            },
-            {
-              level: 14,
-              column_value: '+5',
-            },
-            {
-              level: 15,
-              column_value: '+5',
-            },
-            {
-              level: 16,
-              column_value: '+5',
-            },
-            {
-              level: 17,
-              column_value: '+6',
-            },
-            {
-              level: 18,
-              column_value: '+6',
-            },
-            {
-              level: 19,
-              column_value: '+6',
-            },
-            {
               level: 2,
               column_value: '+2',
             },
             {
-              level: 20,
-              column_value: '+6',
-            },
-            {
               level: 3,
               column_value: '+2',
-            },
-            {
-              level: 4,
-              column_value: '+2',
-            },
-            {
-              level: 5,
-              column_value: '+3',
-            },
-            {
-              level: 6,
-              column_value: '+3',
-            },
-            {
-              level: 7,
-              column_value: '+3',
-            },
-            {
-              level: 8,
-              column_value: '+3',
-            },
-            {
-              level: 9,
-              column_value: '+4',
-            },
+            }
           ],
           feature_type: 'PROFICIENCY_BONUS',
         },
@@ -151,4 +71,16 @@ mockNuxtImport('useFindMany', () => {
       },
     ],
   });
+});
+
+test('/classes/[className] page can mount', async () => {
+  const page = await mountSuspended(ClassPage);
+  expect(page);
+});
+
+test('/classes/[className] page renders title', async () => {
+  const page = await mountSuspended(ClassPage);
+  const title = page.find('h1');
+  expect(title.exists()).toBe(true);
+  expect(title.text()).toEqual(unref(className)?.name);
 });


### PR DESCRIPTION
## Build Preview

https://deploy-preview-771--open5e-preview.netlify.app/

## Description

This PR updates the `/classes/[className]` and `/classes/[className]/[subclassName]` pages to work correctly with the updates to the `/v2/classes` endpoint made in https://github.com/open5e/open5e-api/pull/799 

<img width="680" alt="Screenshot 2025-09-28 at 08 51 56" src="https://github.com/user-attachments/assets/daf7bde2-e054-44e2-a406-93968c163aaf" />

The `/classes/[className]` page is now capable of rendering the Core Traits table included in SRD 2024 class data.

While undertaking this work, I took the opportunity to fold several related bugfixes into this PR. Notably A) class/subclass features now have level annotations next to their title.

<img width="680" alt="Screenshot 2025-09-28 at 08 53 25" src="https://github.com/user-attachments/assets/4de1def5-dadc-4df6-acd0-e2a09849b1cc" />

Level annotations are now included next to the names of class/subclass feature in the Class Feature List. This is essentially for the SRD 2024, which do not include this information in their copy, but is a nice-to-have for existant class data.

<img width="680" alt="Screenshot 2025-09-28 at 08 55 07" src="https://github.com/user-attachments/assets/68106cca-835c-4b7d-8607-35c0a5746397" />

For our SRD-2014 style class information, data in the `hit_points` now renders correctly. This is missing from `staging` because the `"hit_points"` field was not included in the fields requested by the API via fetch query parameters. N.B. that the Hit Points section is mutually exclusive with the Core Traits Table. In this way, the present PR supersedes #769, which will now be closed.

## Related Issue

Closes #753 (level annotation are have been added to class/subclass abilities)
Closes #768 (missing `"hit_points"` query parameter added to fetching method)
Closes #770 (classes and subclasses pages now work with updated ClassFeature API model)
Closes #772 (class and subclass descriptions now render correctly)
Closes #780 (class features of type `"CLASS_FEATURE_OPTION_LIST"` now render correctly underneath features per level list)

## How was this tested?

- Spot checked using a local Nuxt development server `npm run dev`, pulling data from the development branch for https://github.com/open5e/open5e-api/pull/799 running on a local Django server
- `npm run test` (all tests are passing)
- `npm run build` (build process completes without error)

