### PR TITLE
Issue 753 Add level annontations to class features

### DIFF
--- a/app/pages/classes/[className]/index.vue
+++ b/app/pages/classes/[className]/index.vue
@@ -83,7 +83,8 @@
           :id="titleCaseToKebabCase(feature.name)"
           :key="feature.key"
         >
-          <h3>{{ feature.name }}</h3>
+          <h3 class="text-red-400">{{ feature.name }}</h3>
+          <p class="italic text-red-400">{{ "Level " + findFeatureLowestLevel(feature) }}</p>
           <md-viewer
             :text="feature.desc"
             :header-level="3"


### PR DESCRIPTION
## Description

I add a level annotation to the class feature under the name for more visibility
<img width="107" height="107" alt="image" src="https://github.com/user-attachments/assets/99e65407-0a9d-42d3-8dd0-c1f2c89b8abb" />

## Related Issue

*Closes #753*

## How was this tested?

I opened the Barbarian class page and checked that the feature levels are correct. I also verified that when a feature is gained at multiple levels, the lowest level is shown.

*[Link to a staging deploy](#) page if your item can only be seen on certain pages.*

