### PR TITLE
[BUGFIX] `<BreadcrumbLinks>` now correctly renders punctuation

### DIFF
--- a/app/components/BreadcrumbLinks.vue
+++ b/app/components/BreadcrumbLinks.vue
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 /**
  * BreadcrumbLinks.vue - A breadcrumb navigation component that displays a hierarchical navigation path.
  *
@@ -54,6 +54,7 @@
   </nav>
 </template>
 
-<script setup>
-const crumbs = useBreadcrumbs();
+<script setup lang="ts">
+const pageTitle = usePageTitle();
+const crumbs = useBreadcrumbs(pageTitle);
 </script>

--- a/app/composables/useBreadcrumbs.ts
+++ b/app/composables/useBreadcrumbs.ts
@@ -8,31 +8,34 @@ type Breadcrumb = {
   src: string;
 };
 
-export const useBreadcrumbs = () => {
+export const useBreadcrumbs = (titleOverride?: Ref<string | undefined>) => {
   const route = useRoute();
   return computed(() => {
     let url = '';
-    return (
-      route.fullPath
-        .split('/')
-        .map((pathSegment) => {
-          // ignore initial & trailing slashes
-          if (pathSegment === '' || pathSegment === '/') return;
+    const breadcrumbs = route.fullPath
+      .split('/')
+      .map((pathSegment) => {
+        // ignore initial & trailing slashes
+        if (pathSegment === '' || pathSegment === '/') return;
 
-          // rebuild link urls segment by segment
-          url += `/${pathSegment}`;
+        // rebuild link urls segment by segment
+        url += `/${pathSegment}`;
 
-          // return a breadcrumb object
-          return {
-            ...generateTitles(pathSegment),
-            url,
-            src: pathSegment,
-          } as Breadcrumb;
-        })
-
-        // remove null-ish crumbs
-        .filter(breadcrumb => breadcrumb)
-    );
+        // return a breadcrumb object
+        return {
+          ...generateTitles(pathSegment),
+          url,
+          src: pathSegment,
+        } as Breadcrumb;
+      }).filter(breadcrumb => breadcrumb) as Breadcrumb[]; // rmv null crumbs
+    
+    // update title of final crumb is an override is provided
+    const titleOverideValue = unref(titleOverride);
+    if (titleOverideValue && breadcrumbs.length > 0) {
+      breadcrumbs[breadcrumbs.length - 1].title = titleOverideValue;
+    }
+      
+    return breadcrumbs;
   });
 };
 

--- a/app/composables/usePageMetadata.ts
+++ b/app/composables/usePageMetadata.ts
@@ -1,0 +1,39 @@
+type usePageMetadataProps = {
+  title?: MaybeRef<string | undefined>;
+}
+
+let isInitialized = false;
+
+const formatTitle = (title: string) => `${title} | Open5e`;
+
+export const usePageMetadata = (props: usePageMetadataProps = {}) => {
+  const { title } = props;
+  const pageTitle = useState<string | undefined>('pageTitle', () => undefined);
+  const router = useRouter();
+  
+  // reset page title when the route changes
+  if (!isInitialized) {
+    router.afterEach(() => {
+      pageTitle.value = undefined;
+      useHead({ title: 'Open5e' });
+    });
+    isInitialized = true;
+  }
+  
+  // watch the title, updated metadata if it changes
+  if (title) {
+    watchEffect(() => {
+      const titleValue = unref(title);
+      if (!titleValue) return;
+      pageTitle.value = titleValue;
+      useHead({ title: formatTitle(titleValue) });
+    });
+  }
+  
+  // return the title in case we want to use it in a template
+  return { pageTitle };
+};
+
+export const usePageTitle = () => {
+  return useState<string | undefined>('pageTitle', () => undefined);
+};

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -67,15 +67,7 @@
 </template>
 
 <script setup lang="ts">
-// Generate page title from Breadcrumbs
-const BASE_TITLE = 'Open5e';
-const crumbs = useBreadcrumbs();
-const title = computed(() => {
-  if (crumbs.value.length === 0) return BASE_TITLE;
-  return `${crumbs.value.at(-1).title} – ${BASE_TITLE}`;
-});
-useHead({ title: title });
-
+// App UI State
 const isToolbarVisible = ref(false);
 const toggleToolbar = () => (isToolbarVisible.value = !isToolbarVisible.value);
 const isNavbarVisible = ref(false);

--- a/app/pages/backgrounds/[id].vue
+++ b/app/pages/backgrounds/[id].vue
@@ -74,6 +74,8 @@ const { data: background } = useFindOne(
   useRoute().params.id,
 );
 
+usePageMetadata({ title: computed(() => background.value?.name) });
+
 // sort benefits into different sections
 // different sections will be rendered to different parts of the page
 const benefits = computed(() => {

--- a/app/pages/classes/[className]/[subclass].vue
+++ b/app/pages/classes/[className]/[subclass].vue
@@ -39,6 +39,8 @@ const { data: subclassData } = useFindOne(
   },
 );
 
+usePageMetadata({ title: computed(() => subclassData.value?.name) });
+
 const features = computed(() => {
   const features = subclassData.value.features;
   if (!features) return [];

--- a/app/pages/classes/[className]/index.vue
+++ b/app/pages/classes/[className]/index.vue
@@ -112,6 +112,8 @@ const { data: classData } = useFindOne(
   },
 );
 
+usePageMetadata({ title: computed(() => classData.value?.name) });
+
 // fetch subclasses to generate links
 const { data: subclasses } = useFindMany(API_ENDPOINTS.classes, {
   fields: ['key', 'name', 'document'].join(','),

--- a/app/pages/conditions/[id].vue
+++ b/app/pages/conditions/[id].vue
@@ -22,6 +22,8 @@ const { data: condition } = useFindOne(
   { params: { fields: ['name', 'desc', 'document'].join(',') } },
 );
 
+usePageMetadata({ title: computed(() => condition.value?.name) });
+
 // generate source key from page URL - for use with source-tab cmpnt
 const sourceKey = computed(() => {
   if (!condition?.value?.document) return;

--- a/app/pages/equipment/[id].vue
+++ b/app/pages/equipment/[id].vue
@@ -142,6 +142,8 @@ const { data: item } = useFindOne(
   { is_magic_item: false },
 );
 
+usePageMetadata({ title: computed(() => item.value?.name) });
+
 const formatCost = (input) => {
   const [gold, rest] = input.split('.');
   const [silver, copper] = rest.split('');

--- a/app/pages/feats/[id].vue
+++ b/app/pages/feats/[id].vue
@@ -31,6 +31,8 @@ const { data: feat } = useFindOne(API_ENDPOINTS.feats, useRoute().params.id, {
   fields: ['name', 'desc', 'prerequisite', 'document'],
 });
 
+usePageMetadata({ title: computed(() => feat.value?.name) });
+
 // generate source key from page URL - for use with source-tab cmpnt
 const sourceKey = computed(() => {
   if (!feat?.value?.document) return;

--- a/app/pages/legal/[id].vue
+++ b/app/pages/legal/[id].vue
@@ -8,4 +8,5 @@
 <script setup>
 
 const { data: license } = useFindOne(API_ENDPOINTS.licenses, useRoute().params.id);
+usePageMetadata({ title: computed(() => license.value?.name) });
 </script>

--- a/app/pages/magic-items/[id].vue
+++ b/app/pages/magic-items/[id].vue
@@ -40,4 +40,6 @@ const { data: item } = useFindOne(
   API_ENDPOINTS.magicitems,
   useRoute().params.id,
 );
+usePageMetadata({ title: computed(() => item.value?.name) });
+
 </script>

--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -330,6 +330,8 @@ const { data: monster } = useFindOne(
   { params },
 );
 
+usePageMetadata({ title: computed(() => monster.value?.name) });
+
 // Calculate initiative bonus from dexterity modifier if not explicitly set
 const initiativeBonus = computed(() => {
   if (!monster.value) return 0;

--- a/app/pages/rules/[id].vue
+++ b/app/pages/rules/[id].vue
@@ -17,4 +17,6 @@
 
 <script setup>
 const { data: ruleset } = useFindOne(API_ENDPOINTS.rules, useRoute().params.id);
+usePageMetadata({ title: computed(() => ruleset.value?.name) });
+
 </script>

--- a/app/pages/sources/[id].vue
+++ b/app/pages/sources/[id].vue
@@ -41,4 +41,6 @@
 <script setup>
 const { data: document } = useFindOne(API_ENDPOINTS.documents, useRoute().params.id);
 
+usePageMetadata({ title: computed(() => document.value?.name) });
+
 </script>

--- a/app/pages/species/[id].vue
+++ b/app/pages/species/[id].vue
@@ -75,6 +75,9 @@ const { data: species } = useFindOne(API_ENDPOINTS.species, useRoute().params.id
   params: { subspecies_of__isnull: true },
 });
 
+usePageMetadata({ title: computed(() => species.value?.name) });
+
+
 const { data: subspecies } = useFindMany(API_ENDPOINTS.species, {
   subspecies_of__key__in: useRoute().params.id,
 });

--- a/app/pages/spells/[id].vue
+++ b/app/pages/spells/[id].vue
@@ -86,7 +86,7 @@
 <script setup>
 const { data: spell } = useFindOne(API_ENDPOINTS.spells, useRoute().params.id);
 
-usePageMetadata({ title: computed(() => spell.value.name) });
+usePageMetadata({ title: computed(() => spell.value?.name) });
 
 function formatComponents(verbal, somatic, material) {
   const components = [];

--- a/app/pages/spells/[id].vue
+++ b/app/pages/spells/[id].vue
@@ -86,6 +86,8 @@
 <script setup>
 const { data: spell } = useFindOne(API_ENDPOINTS.spells, useRoute().params.id);
 
+usePageMetadata({ title: computed(() => spell.value.name) });
+
 function formatComponents(verbal, somatic, material) {
   const components = [];
   if (verbal) components.push('V');


### PR DESCRIPTION
## Build Preview

https://deploy-preview-774--open5e-preview.netlify.app/

## Description

This PR fixes a bug where the `<BreadcrumbLinks>` component didn't render any of punctiation in a given page's title.

`/monsters/tob2_a-mi-kuk` (compare to screenshot from issue #623)

<img width="792" height="448" alt="Screenshot 2025-10-05 at 13 01 09" src="https://github.com/user-attachments/assets/d87e0cb3-d4ae-4ef6-8ef1-ef37d15941da" />


This error occured because, previously, Breadcrumbs were all generated directly from the page slug, and punctuation is stripped during slugification. So there is was no way to retain punctuation data.

To solve this issue, an optional title override parameter was added to the `useBreadcrumbs()` composable. However, this left us with the issue of how to pass the page title data from page components (where it is fetched) to the invocation of the `<BreadcrumbLinks>` component in the default layout. To achieve this, the `usePageMetadata()` composable was authored with the intent of making page metadata (such as the Title) editible and accessible across the application.

A welcome but unintended side effect is that this also fixed the page/tab titles, where the same missing punctuation issue was occuring

## Related Issue

Closes #623 

## How was this tested?

- Spot checked using local Nuxt development server (`npm run dev`) pulling data from a local Django development server running the `staging` branch of the API
- `npm run test` (all tests passing)
- `npm run build` (confirming that build process completes without error