### PR TITLE
[BUGFIX] Feat `"benefits"` array now render correctly

### DIFF
--- a/app/pages/feats/[id].vue
+++ b/app/pages/feats/[id].vue
@@ -18,7 +18,7 @@
 
       <MdViewer :text="feat.desc" />
 
-      <ul v-if="feat.benefits.length > 0">
+      <ul v-if="feat.benefits">
         <li v-for="(benefit, index) in feat.benefits" :key="index">
           <MdViewer :text="benefit.desc" />
         </li>

--- a/app/pages/feats/[id].vue
+++ b/app/pages/feats/[id].vue
@@ -15,10 +15,14 @@
         <span class="font-bold after:content-['._']">Prerequistes</span>
         <span>{{ feat.prerequisite }}</span>
       </p>
-      <md-viewer
-        :text="feat.desc"
-        class="list-disc"
-      />
+
+      <MdViewer :text="feat.desc" />
+
+      <ul v-if="feat.benefits.length > 0">
+        <li v-for="(benefit, index) in feat.benefits" :key="index">
+          <MdViewer :text="benefit.desc" />
+        </li>
+      </ul>
     </section>
   </main>
   <p v-else>
@@ -26,9 +30,17 @@
   </p>
 </template>
 
-<script setup>
-const { data: feat } = useFindOne(API_ENDPOINTS.feats, useRoute().params.id, {
-  fields: ['name', 'desc', 'prerequisite', 'document'],
+<script setup lang="ts">
+// cast 'id' as string (if string[])
+const id = computed(() => {
+  const param = useRoute().params.id;
+  return Array.isArray(param) ? param[0] : param;
+});
+
+const { data: feat } = useFindOne(API_ENDPOINTS.feats, id, {
+  params: {
+    fields: ['name', 'desc', 'prerequisite', 'document', 'benefits'].join(','),
+  },
 });
 
 // generate source key from page URL - for use with source-tab cmpnt

--- a/tests/unit/pages/feat.test.tsx
+++ b/tests/unit/pages/feat.test.tsx
@@ -28,6 +28,7 @@ mockNuxtImport('useFindOne', () => {
         name: 'Systems Reference Document',
         url: 'v2/documents/srd/"',
       },
+      benefits: [],
     },
   });
 });


### PR DESCRIPTION
## Build Preview
https://deploy-preview-776--open5e-preview.netlify.app/

## Description

This PR fixes a bug on the `/feats/[id]` page where a feat's benefits (as listed in the `"benefits"` array) were not being rendered to the page:

<img width="1180" height="347" alt="Screenshot 2025-10-07 at 11 18 56" src="https://github.com/user-attachments/assets/21b8373a-9638-4a43-baa4-84351217dac8" />

Resolving this issue required updated the query parameters of the fetch request to the API, and then adding markup to the template tag to correctly render the information returned.

## Related Issue

 Closes #775

## How was this tested?
- Spot checked on local Nuxt server (`npm run dev`) pulling data from `staging` branch of the API
- `npm run test` (all tests passing)
- `npm run build` (build process completes without error)