### PR TITLE
[UX] Paginated content can now be navigated using left- and right- arrow keys

### DIFF
--- a/app/components/ResultsTablePaginator.vue
+++ b/app/components/ResultsTablePaginator.vue
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 /**
  * ApiTableNav.vue - Pagination controls, designed to be used with the
  * `<ResultsTable />` component
@@ -56,7 +56,7 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 const props = defineProps({
   lastPageNumber: { type: Number, default: 1 },
   pageNumber: { type: Number, default: 1 },
@@ -64,6 +64,14 @@ const props = defineProps({
   totalItems: { type: Number, default: 1 },
 });
 const emit = defineEmits(['first', 'last', 'next', 'prev']);
+
+// keyboard control for pagination
+const handleKeyDown = (event: KeyboardEvent) => {
+  if (event.key === 'ArrowRight') emit('next');
+  else if (event.key === 'ArrowLeft') emit('prev');
+};
+onMounted(() => document.addEventListener('keydown', handleKeyDown));
+onBeforeUnmount(() => document.removeEventListener('keydown', handleKeyDown));
 
 // conditional properties control whenever certain buttons are enabled
 const isNotFirstPage = computed(() => props.pageNumber > 1);

--- a/app/composables/useFindPaginated.ts
+++ b/app/composables/useFindPaginated.ts
@@ -78,8 +78,12 @@ export function useFindPaginated<T extends keyof EndpointToPaginatedTypeMap>(opt
 });
 
   // pagination controls
-  const nextPage = () => pageNo.value++;
-  const prevPage = () => pageNo.value--;
+  const nextPage = () => {
+    if (pageNo.value < lastPageNo.value) pageNo.value++;
+  };
+  const prevPage = () => {
+    if (pageNo.value > 1) pageNo.value--;
+  };
   const firstPage = () => pageNo.value = 1;
   const lastPage = () => pageNo.value = lastPageNo.value ?? pageNo.value;
 


### PR DESCRIPTION
## Description

This PR adds additional functionality to the `ResultsTablePaginator` component. Now users are able to navigate between pages of results using the left- and right- arrow keys in addition to the button. From a UX perspective, quite nice.

Clamping logic was added to the `useFindPaginated` composable to stop users from being able to paginate out of bounds.

## Related Issue

Closes #561 

## Test Deploy

Visit the following page to observe the changes in action. Open the link and navigate through pages of spells using the left- and right- arrow keys!

https://deploy-preview-786--open5e-preview.netlify.app/spells

## How was this tested?
- Spot checked on a local Nuxt development server (`npm run dev`), pulling data from a Django test server running the `staging branch of the Open5e API.
- `npm run test` (all tests passing)
- `npm run build)` (build process completes without error)