### PR TITLE
Fix random horizontal rule on background pages

### DIFF
--- a/assets/_docs.scss
+++ b/assets/_docs.scss
@@ -88,18 +88,10 @@ table {
 
 .docs-container {
   hr {
-    margin: 1rem 0;
-    height: 2px;
-    background: linear-gradient(
-      to right,
-      rgba($color-blood, 1) 0%,
-      rgba($color-blood, 0) 100%
-    );
-    border: 0;
+    display: none; // Hide all hr elements in docs container as they serve no functional purpose
   }
   p,
   ul,
-  hr,
   h1,
   h2,
   h3,


### PR DESCRIPTION
## Description
Fixes the visual bug where a random gray horizontal rule (`<hr>`) appears in the middle of background detail pages, specifically between the **Feature** and **Suggested Characteristics** sections.

## Changes Made
- Modified `assets/_docs.scss` to hide all `<hr>` elements within `.docs-container`
- The horizontal rules appear to be artifacts from markdown processing that serve no functional purpose
- This change only affects pages using the `.docs-container` class (like background detail pages)

## Testing
The fix can be verified by visiting any background page (e.g., `/backgrounds/srd_acolyte`) and confirming that the gray horizontal rule no longer appears between sections.

## Issue
Fixes #790

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update