### PR TITLE
Removed unwanted `<hr>` from `/backgrounds/[id]` page

### DIFF
--- a/app/pages/backgrounds/[id].vue
+++ b/app/pages/backgrounds/[id].vue
@@ -42,7 +42,6 @@
         <md-viewer :text="benefit.desc" />
       </li>
     </ul>
-    <hr />
 
     <!-- List of background flavour, rollable tables, etc. -->
     <ul>


### PR DESCRIPTION
## Description

This PR fixes a layout issue on the `/background/[id]` page where a weird horizontal rule ran through the middle of the page.  It didn't look great, likely an artefact of previous iteration of this page, so I have removed it.

<img width="800" alt="Screenshot 2025-12-31 at 13 39 16" src="https://github.com/user-attachments/assets/765464d4-a2ac-4c10-ac97-c0f036acab1f" />


## Related Issue

Closes #790

## How was this tested?

- Spot checked on local Nuxt development server (pulling data from the `staging` branch of the Open5e API, running on a local Django development server)
- `npm run test` (all tests passing)
- `npm run build` (build process completes without error)