### PR TITLE
Bugfix: `<strong>` now always rendered inline by `MdViewer` component

### DIFF
--- a/app/components/MdViewer.vue
+++ b/app/components/MdViewer.vue
@@ -72,7 +72,7 @@ const extensions = computed(() => {
 <style>
 .markdown-inline {
   display: inline;
-  :not(ul, table, th, td, tr, thead, tbody) {
+  :not(ul, table, th, td, tr, thead, tbody, strong) {
     display: inherit;
   }
 }


### PR DESCRIPTION
## Description

This PR fixes a bug where `<strong>` tags were being rendered as block-elements by the `<MdViewer>` component when the `inline` property was set to True.

The issue was fixed by adding the `strong` element to the list of element selectors that which should have the assigned the `display: inherit` CSS property.

## Related Issue

Closes #799 

## How was this tested?
- `npm run build` (build process completes without error)
- `npm run test` (all tests passing)
- Spot checked on local Nuxt development server