### PR TITLE
Update `spell/[id]` page layout (closes #789)

### DIFF
--- a/app/components/ToolButtonSourceSelector.vue
+++ b/app/components/ToolButtonSourceSelector.vue
@@ -7,7 +7,7 @@
     <Icon name="majesticons:book-open-line" class="z-20 size-6"/>
     <p
       v-if="sourceCount" 
-      class="absolute -bottom-3 z-30 text-nowrap px-0.5 py-0 text-xs text-black  dark:text-white"
+      class="absolute -bottom-3 z-30 my-0 text-nowrap py-0 text-xs text-black  dark:text-white"
     >
       {{ sourceCount }}
     </p>

--- a/app/pages/spells/[id].vue
+++ b/app/pages/spells/[id].vue
@@ -1,86 +1,81 @@
 <template>
-  <section
-    v-if="spell"
-    class="docs-container container"
-  >
+  <main v-if="spell">
     <h1>{{ spell.name }}</h1>
-    <p>
-      <span
-        v-if="spell.level == 0"
-        class="italic"
-      >
-        {{ `${spell.school.name} cantrip` }}
+    <p  class="italic">
+      <span v-if="spell.level == 0">
+        {{ `${spell.school.name} Cantrip` }}
       </span>
-      <span
-        v-else
-        class="italic"
-      >
-        {{ `Level ${spell.level} ${spell.school.name} spell` }}
+      <span v-else>
+        {{ `Level ${spell.level} ${spell.school.name} Spell` }}
       </span>
       <span v-if="spell.ritual"> (ritual)</span>
-      <span
-        v-if="spell.classes.length > 0"
-        class="before:content-['_|_']"
-      >
-        {{ spell.classes.map((c) => c.name).join(', ') }}
+      <span v-if="spell.classes.length > 0">
+        {{ " (" + spell.classes.map((c) => c.name).join(', ') + ")" }}
       </span>
+
       <SourceTag
         v-show="spell.document.key"
         :title="spell.document.name"
         :text="spell.document.key"
       />
     </p>
-    <p><label class="font-bold">Range:</label> {{ spell.range_text }}</p>
-    <p>
-      <label class="font-bold">Casting Time:</label> {{ spell.casting_time }}
-    </p>
-    <p>
-      <label class="font-bold">Duration: </label>
-      <span v-if="spell.concentration">
-        Concentration, up to {{ spell.duration }}
-      </span>
-      <span v-else>{{ spell.duration }}</span>
-    </p>
-    <p>
-      <label class="font-bold">Components: </label>
-      <span>
-        {{ formatComponents(spell.verbal, spell.somatic, spell.material) }}
-        <b v-if="spell.material_consumed">*</b>
-      </span>
-      <span
-        v-if="spell.material_specified"
-        class="font-medium text-slate-600 dark:text-slate-300"
-      >
-        ({{ spell.material_specified }})
-        <!-- Removes trailing preiod -->
-      </span>
-    </p>
-    <MdViewer
-      :text="spell.desc"
-      :use-roller="true"
-    />
-    <p v-if="spell.higher_level">
-      <label class="font-bold">At higher levels:</label>
-      <MdViewer :text="spell.higher_level" />
-    </p>
+
+    <section class="my-4">
+      <p class="my-0 grid grid-cols-[10rem,_1fr]">
+        <span class="font-bold">Casting Time: </span>
+        <span class="capitalize">{{ spell.casting_time }}</span>
+      </p>
+      <p class="my-0 grid grid-cols-[10rem,_1fr]">
+        <span class="font-bold">Range: </span>
+        <span class="capitalize">{{ spell.range_text }}</span>
+      </p>
+      <p class="my-0 grid grid-cols-[10rem,_1fr]">
+        <span class="font-bold">Duration: </span>
+        <span class="capitalize">{{
+          spell.concentration 
+            ? `Concentration, up to ${spell.duration}`
+            : spell.duration
+          }}
+        </span>
+      </p>
+      <p class="my-0 grid grid-cols-[10rem,_1fr]">
+        <span class="font-bold">Components: </span>
+        <span>
+          <span>
+            {{ formatComponents(spell.verbal, spell.somatic, spell.material) }}
+          </span>
+          <b v-if="spell.material_consumed">*</b>
+          <span v-if="spell.material_specified" class="text-slate-600 dark:text-slate-300"
+          >
+            ({{ spell.material_specified }})
+          </span>
+        </span>
+      </p>
+    </section>
+
+    <section>
+      <MdViewer
+        :text="spell.desc"
+        :use-roller="true"
+      />
+    </section>
+
+    <section v-if="spell.higher_level" class="mt-4 ">
+      <h2 class="inline border-b-0 text-base font-bold no-underline">
+        {{ spell.level > 0 ? "Using a High-Level Spell Slot: " : "Cantrip Upgrade: " }}
+      </h2>
+      <MdViewer :text="spell.higher_level" :inline="true" />
+    </section>
+
     <p class="text-sm italic">
-      Source:
-      <a
-        target="NONE"
-        :href="spell.document.permalink"
-      >
+      <span>Source: </span>
+      <NuxtLink :to="`/sources/${spell.document.key}`">
         {{ spell.document.name }} by
         {{ spell.document.publisher.name || 'unknown publisher' }}
         <Icon name="heroicons:arrow-top-right-on-square-20-solid" />
-      </a>
+      </NuxtLink>
     </p>
-  </section>
-  <section
-    v-else
-    class="docs-container container"
-  >
-    Loading...
-  </section>
+  </main>
 </template>
 
 <script setup lang="ts">

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -71,11 +71,7 @@ h6 {
 }
 
 p {
-  margin-top: var(--pad-md);
-}
-
-p:not(:first-child) {
-  margin-top: var(--pad-sm);
+  margin-block: var(--pad-sm);
 }
 
 h1,


### PR DESCRIPTION
## Description

This PR slightly refactors and re-styles the `/spells/[id]` page. All changes mentioned in issue #789 have been addressed. A before/after can be seen in the *Screenshots* section.

Additionally, care has been taken so that copying and pasting from the website into a Markdown editor preserves as much of the page's structure as possible.

## Related Issue

Closes #789 

## How was this tested?

- Spot checked on local Nuxt development server (`npm run dev`)
- Build process (`npm run build`) completes without error
- All tests passing (`npm run test`)

## Screenshots

Before:

<img width="700" alt="Screenshot 2026-01-09 at 10 37 12" src="https://github.com/user-attachments/assets/afde3517-6497-45f3-b920-c5bdfea6fb25" />

After:

<img width="700" height="609" alt="Screenshot 2026-01-09 at 10 37 29" src="https://github.com/user-attachments/assets/b2f69038-df11-4781-a552-5367e1c7e086" />
