### PR TITLE
refactored MdViewer to correctly handle ul's and displayer inheritance

### DIFF
--- a/app/components/MdViewer.vue
+++ b/app/components/MdViewer.vue
@@ -33,7 +33,7 @@
     }"
     :markdown="text"
     :extensions="extensions"
-    :class="inline ? 'markdown-inline' : ''"
+    :class="inline ? 'markdown markdown-inline' : 'markdown'"
   />
 </template>
 
@@ -70,9 +70,16 @@ const extensions = computed(() => {
 </script>
 
 <style>
+.markdown {
+  ul {
+    list-style-type: disc;
+    margin-left: 1rem;
+  }
+}
+
 .markdown-inline {
   display: inline;
-  :not(ul, table, th, td, tr, thead, tbody, strong) {
+  p, div {
     display: inherit;
   }
 }

--- a/app/pages/feats/[id].vue
+++ b/app/pages/feats/[id].vue
@@ -5,7 +5,7 @@
   >
     <h1>
       <span>{{ feat.name }}</span>
-      <source-tag
+      <SourceTag
         :text="sourceKey"
         :title="feat.document.name"
       />
@@ -18,9 +18,9 @@
 
       <MdViewer :text="feat.desc" />
 
-      <ul v-if="feat.benefits">
+      <ul v-if="feat.benefits" class="ml-4 mt-2 list-disc">
         <li v-for="(benefit, index) in feat.benefits" :key="index">
-          <MdViewer :text="benefit.desc" />
+          <MdViewer :text="benefit.desc" :inline="true"/>
         </li>
       </ul>
     </section>
@@ -40,7 +40,7 @@ const { data: feat } = useFindOne(API_ENDPOINTS.feats, featId, {
 
 usePageMetadata({ title: computed(() => feat.value?.name) });
 
-// generate source key from page URL - for use with source-tab cmpnt
+// generate source key from page URL - for use with source-tag cmpnt
 const sourceKey = computed(() => {
   if (!feat?.value?.document) return;
   return feat.value.document.key;

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -163,19 +163,6 @@ td {
   display: inline-block;
 }
 
-.docs-toc ul {
-  font-size: 1.2rem;
-  list-style: none;
-  padding-left: 0;
-  line-height: 1.5rem;
-}
-
-.docs-toc ul ul {
-  padding-left: var(--pad-sm);
-  font-size: 1.1rem;
-}
-
-
 blockquote {
   padding: 0.1rem 1rem 1rem 1rem;
   margin-top: 1rem;


### PR DESCRIPTION
## Description

This PR fixes two issues with the `MdViewer` component:

1. Certain Markdown elements that ought to be rendered as inline were being displayed as block elements (#801)
2. Lists in Markdown fields were missing their bullet points (#803) 

Both of these issues could be addressed by updating the Style tag in the `MdViewer.vue` component.

To address point 1, the inline styles selectors were updated so that they only applied to `p` and `div` elements. Functionally this has the same effect as the previous iteration of the class, only it is less likely to accidently tell an element to inherit a `display: block` property from a parent.

Point 2 was addressed by adding some additional styling to `ul` components in the `MdViewer.vue` CSS. Some over-zealous code in the CSS reset was also interfering with the application of the new `ul` classes, so this was pruned back.

The only pages that this didn't work for was the `/feats/[id]` page. This is beacuse the `ul` element is a parent to the `MdViewer` component, so it styles are out of scope. This was easily fixed by adding some TailwindCSS styles to the `ul` element.

## Related Issue

Closes #801 

Closes #803 

## How was this tested?

- Spot checked on local Nuxt development server (`npm run dev`)
- Build process completes without errors (`npm run build`)
- All tests are passing (`npm run test`)
