### PR TITLE
Bugfix: added redirects from /spells/by-class -> /spells

### DIFF
--- a/app/middleware/redirects.global.js
+++ b/app/middleware/redirects.global.js
@@ -13,6 +13,7 @@ const partialMatchesToRedirect = [
   { find: '/characters', to: '/rules' },
   { find: '/gameplay-mechanics', to: '/rules' },
   { find: '/running', to: '/rules' },
+  { find: '/spells/by-class', to: '/spells'}
 ];
 
 // if a url contains a substring, replace it with another substring


### PR DESCRIPTION
## Description

This PR adds a redirect from the `/spells/by-class` subroute to the `/spells` page. The former has been long deprecated, but the functionality of filtering spells by Class is reproduced on the `/spells page.

## Related Issue

Closes #815


## How was this tested?
- Spot checked on local Nuxt development server
- `npm run build`, build process completes without error
- `npm run test`, all tests passing