### PR TITLE
[FEATURE] Source Selection via route query parameters

### DIFF
--- a/app/middleware/set-sources-via-query-params.global.ts
+++ b/app/middleware/set-sources-via-query-params.global.ts
@@ -1,0 +1,41 @@
+// This middleware strips query params from urls site-wide, and if a `sources` 
+// parameter is present, it uses its payload to update sources in localStroage.
+//
+// ie. `open5e.com/?sources=srd-2024` will redirect to `open5e.com` but will 
+// also update the sources lists so that only `srd-2024` in enabled.
+
+export default defineNuxtRouteMiddleware((to) => {
+  if (import.meta.server) return;
+  const [path, queryString] = to.fullPath.split('?');
+
+  if (!queryString) return;
+
+  const params = parseQueryString(queryString);
+  const sources = params?.['sources'];
+
+  if (!sources) return;
+  
+  const { setSources } = useSourcesList();
+  setSources(sources);
+  return navigateTo(path);   // redirect to path w/o query parameters
+});
+
+function parseQueryString(input: string): Record<string, string[]> {
+  if (!input) return {};
+
+  const queryString = sanitizeQueryString(input);
+  const output = {} as Record<string, string[]>;
+
+  queryString.split('&').forEach((property) => {
+      const [propName, values] = property.split('=');
+      output[propName] = values.split(',');
+    }
+  );
+
+  return output;
+}
+
+// filter characters we wouldn't expect in a query string to help prevent XSS
+function sanitizeQueryString(input: string): string {
+  return input.replace(/[^a-zA-Z0-9_&,=-]/g, '');
+}


### PR DESCRIPTION
## Description

This PR fulfills a feature request for a method of setting which Open5e by passing a query parameter along with the URL.

This was achieved by writing a piece of middleware that checks for route query parameters, sanitizes it, checks for the presence of a `sources` parameter, and then updates the sources local storage via the `useSourcesList()` composable. The middleware then redirects the user back to the same page, but with the query parameters stripped from the URL.

### Usage

`open5e.com/?sources=srd-2024` would redirect to `open5e.com` and would update sources so that only `srd-2024` is enabled.

`open5e.com/monsters/?sources=srd-2014,srd-2024` would redirect to `open5e.com/monsters` and would update sources so that only `srd-2014` and `srd-2024` were enabled.

## Related Issue

Closes #798 

## How was this tested?
- Spot checked on local Nuxt development server
- `npm run build` (build process completes without error)
- `npm run test` (all tests are passing)
