### PR TITLE
Non-source Documents no longer togglable in Source Selector

### DIFF
--- a/app/components/ModalSourceSelector.vue
+++ b/app/components/ModalSourceSelector.vue
@@ -171,26 +171,38 @@
 import { sortDocumentsByPublisher } from '@/helpers';
 import type { Document } from '@/types';
 
-// fetch full list of document sources
+const emit = defineEmits(['close']);
+const closeModal = () => emit('close');
+
 const { data: documents } = useDocuments({
-  fields: ['key', 'name', 'publisher', 'gamesystem'].join(','),
+  fields: ['key', 'name', 'publisher', 'gamesystem', 'type'].join(','),
   publisher__fields: ['name', 'key'].join(','),
   gamesystem__fields: ['name', 'key'].join(','),
 });
 
 const { sources, setSources, gameSystem, setGameSystem } = useSourcesList();
-const selectedSources: Ref<string[]> = ref([]);
-const emit = defineEmits(['close']);
-const closeModal = () => emit('close');
+
+
+// Seperate SOURCE and MISC documents, only use the former in the modal menu
+// and add the later back in when updating selected sources in local memory
+
+const sourceDocuments = computed(() => (
+  documents?.value?.filter(document => document.type === 'SOURCE') ?? []
+));
+
+const miscDocuments = computed(() => (
+  documents?.value?.filter(document => document.type !== 'SOURCE') ?? []
+));
 
 // Keep selectedSources in sync with global sources state
+const selectedSources: Ref<string[]> = ref([]);
 watchEffect(() => selectedSources.value = [...sources.value]);
 
 // filter documents by the current game system
 const documentsInSystem = computed<Document[]>(() => {
-  if (!documents.value) return [];
-  if (!currentSystem.value) return documents.value;
-  return documents.value.filter((document) => {
+  if (!sourceDocuments?.value || sourceDocuments.value.length === 0) return [];
+  if (!currentSystem.value) return sourceDocuments.value;
+  return sourceDocuments.value.filter((document) => {
     return document.gamesystem.name === currentSystem.value;
   });
 });
@@ -237,7 +249,10 @@ const onGameSystemChanged = (event: Event) => {
 
 // save current form selection to local memory
 function saveSelection() {
-  setSources(selectedSources.value);
+  setSources([
+    ...selectedSources.value,
+    ...miscDocuments.value.map(document => document.key)
+  ]);
   setGameSystem(currentSystem.value);
   closeModal();
 }

--- a/app/components/ToolButtonSourceSelector.vue
+++ b/app/components/ToolButtonSourceSelector.vue
@@ -6,10 +6,10 @@
   >
     <Icon name="majesticons:book-open-line" class="z-20 size-6"/>
     <p
-      v-if="sourceCount" 
+      v-if="selectedSourcesFraction" 
       class="absolute -bottom-3 z-30 my-0 text-nowrap py-0 text-xs text-black  dark:text-white"
     >
-      {{ sourceCount }}
+      {{ selectedSourcesFraction }}
     </p>
 
     <ModalSourceSelector 
@@ -23,12 +23,17 @@
 <script setup lang="ts">
 const showModal = ref(false);
 
-const { data: documents } = useDocuments({ fields: 'key' });
-
+const { data: documents } = useDocuments({ fields: 'key', type: 'SOURCE' });
 const { sources } = useSourcesList();
-const sourceCount = computed(() => {
+
+const selectedSourcesFraction = computed(() => {
   if (!sources.value || !documents.value) return '';
-  return `${sources.value?.length}/${documents.value?.length}`;
+  const allSourceDocumentKeys = documents.value.map(document => document.key);
+  const numerator = sources.value
+    .filter(source => allSourceDocumentKeys.includes(source))
+    .length;
+  const denominator = documents.value?.length;
+  return `${numerator}/${denominator}`;
 });
 
 </script>

--- a/app/composables/useSourcesList.ts
+++ b/app/composables/useSourcesList.ts
@@ -29,8 +29,9 @@ const setGameSystem = (input: string) => {
 
 // Overwrite all sources, update local storage
 export const setSources = (sources: string[]) => {
-  _sources.value = sources;
-  writeSourcesToLocalStorage(sources);
+  const dedupedSources = [...new Set(sources)];
+  _sources.value = dedupedSources;
+  writeSourcesToLocalStorage(dedupedSources);
 };
 
 export const read_only_source_list = computed(() => _sources.value);

--- a/app/types/open5e-api.ts
+++ b/app/types/open5e-api.ts
@@ -2052,6 +2052,13 @@ export interface components {
              * @enum {string|null}
              */
             weight_unit?: 'feet' | 'miles' | '' | null;
+            /**
+             * @description Whether this Document is a published data source, or general resources.
+             *     * `SOURCE` - Source
+             *     * `MISC` - Miscellaneous
+             *  @enum {string|null}
+             */
+            type?: 'SOURCE' | 'MISC' | '' | null;
         };
         /**
          * @description A slimmer DocumentSerializer, designed to serialize Documents FKs on other


### PR DESCRIPTION
## Description

This PR fixes an issue where data from certain Documents which are *not* sources of game content (ie. icons, containers for linking together content across multiple systems) were togglable 

The `"MISC"` type Documents are still stored in local storage via the `useSourcesList` composable, but are seperated from the `"SOURCE"` type documents in the `ModalSourceSelector` component, and added back in when sources are saved.

Additional updates were required to the `useSourcesList` composable (to better guard against duplication of sources in local memory) and `/types` (where the `Document` type was slightly out of date compared to the API)

## Related Issue

Closes #819 

## How was this tested?
- Spot checked on local Nuxt development server
- `npm run build` (build process completes without error)
- `npm run test` (all tests passing)
