### PR TITLE
[BUGFIX] Reaction conditions now displayed on `spells/[id]`

### DIFF
--- a/app/pages/spells/[id].vue
+++ b/app/pages/spells/[id].vue
@@ -23,11 +23,11 @@
     <section class="my-4">
       <p class="my-0 grid grid-cols-[10rem,_1fr]">
         <span class="font-bold">Casting Time: </span>
-        <span class="capitalize">{{ spell.casting_time }}</span>
+        <span>{{ formatCastingTime(spell) }}</span>
       </p>
       <p class="my-0 grid grid-cols-[10rem,_1fr]">
         <span class="font-bold">Range: </span>
-        <span class="capitalize">{{ spell.range_text }}</span>
+        <span>{{ spell.range_text }}</span>
       </p>
       <p class="my-0 grid grid-cols-[10rem,_1fr]">
         <span class="font-bold">Duration: </span>
@@ -79,10 +79,24 @@
 </template>
 
 <script setup lang="ts">
+import type { Spell } from '@/types';
 const spellId = useQueryParameter('id'); 
 const { data: spell } = useFindOne(API_ENDPOINTS.spells, spellId);
 
 usePageMetadata({ title: computed(() => spell.value?.name) });
+
+function formatCastingTime(spell: Spell) {
+  const { casting_time, reaction_condition } = spell;
+  
+  const formattedTitle = casting_time
+    .split('-').join(' ') // rmv '-' from 'bonus-action'
+    .replace(/(\d+)([a-zA-Z]+)/, '$1 $2') // insert space into '1hour', etc.
+    .replace(/^./, casting_time[0].toUpperCase());
+    
+  if (reaction_condition) return `${formattedTitle}, ${reaction_condition}`;
+
+  return formattedTitle;
+}
 
 function formatComponents(verbal?: boolean, somatic?: boolean, material?: boolean) {
   return [


### PR DESCRIPTION
## Description

This PR adds Spells `"reaction_condition"`, where present, to data displayed on the `/spells/[id]` page.

Screenshot from the feature branch (running on local Nuxt development server):

<img width="800" alt="Screenshot 2026-02-06 at 09 38 56" src="https://github.com/user-attachments/assets/783b6e37-c0ec-46c1-a13c-523bb4cb9486" />

Notice that next to the **Casting Time** label, conditions for triggering the reaction are appended to the end of the reaction action type.

Compare to a screenshot of the same page from [beta site](https://beta.open5e.com/spells/srd-2024_shield):
<img width="600" alt="Screenshot 2026-02-06 at 09 38 14" src="https://github.com/user-attachments/assets/6db57edf-7f3b-44b2-bc61-2047bbc114a8" />



## Related Issue

Closes #821 

## How was this tested?
- Spot checked on local Nuxt development server
- `npm run test` (all tests passing)
- `npm run build` (build process completes without error)

