### PR TITLE
[BUGFIX] Fixed 301s on `useFindOne` calls without query parameters

### DIFF
--- a/app/composables/useFindOne.ts
+++ b/app/composables/useFindOne.ts
@@ -2,12 +2,12 @@ import type { EndpointToFindOneTypeMap } from './api';
 
 function formatQueryString(params?: Record<string, string>): string {
   // iterate over params: format as string[] of the form `field=value`
-  if (!params) return '';
+  if (!params) return '/';
   const formattedParams = Object.entries(params).map(
     (([field, value]) => `${field}=${value}`)
   );
 
-  return formattedParams.length === 0 ? '' : `/?${formattedParams.join('&')}`;
+  return formattedParams.length === 0 ? '/' : `/?${formattedParams.join('&')}`;
 }
 
 export function useFindOne<T extends keyof EndpointToFindOneTypeMap>(


### PR DESCRIPTION
## Description

This PR fixes a small bug on the `useFindOne` composable. Queries made without any query parameters were returning a 301 status code before returning 200. This was due to the terminal slash not being added correctly to the query string for endpoints without query parameters.

THe issue was fixed by ensuring that  the `formatQueryString()` function returned `"/"` rather than `""` as its base-case null type.

## Related Issue

Closes #846 

## How was this tested?
- Spot checked on local Nuxt development server
- `npm run build` (build process completes on local without error)
- `npm runn test` (all tests passing on local)