### PR TITLE
[CI/CD] Updated Github Actions Node v20 -> v24

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - run: npm ci
       - run: npm run build
       - run: npm run generate


### PR DESCRIPTION
## Description

This PR updates the version of Node that we use in our Github Actions PR Validation from v20 to v24. Node 20 will no longer be supported in the Summer.


## Related Issue

Closes #847 

## How was this tested?

- Opened PR to check that PR validation runs correctly

