### PR TITLE
fixed bug on /rules -> links now link to /rules/[id], not /species/[id]

### DIFF
--- a/app/helpers/resultsTableConfig/rules.ts
+++ b/app/helpers/resultsTableConfig/rules.ts
@@ -10,6 +10,6 @@ export const rulesTableColumnDefinitions: TableColumn<RuleSet>[] = [
     displayName: 'Name',
     value: (data) => data.name,
     sortValue: 'name',
-    link: (data) => `/species/${data.key}`,
+    link: (data) => `/rules/${data.key}`,
   }
 ];


### PR DESCRIPTION
## Description

This PR fixes a bug on the `/rules` page where Rule keys/UIDs were being access via the`/species/[id]` page.

The issue was located in the results table config data, and was likely resulted from some gung ho copying and pasting during the resent `<ResultsTable>` refactor (issue #839).

## Related Issue

Closes #864 

## How was this tested?

- Spot checked on local Nuxt development server
- `npm run test` (all tests are passing)
- `npm run build` (build process completes without error)