### PR TITLE
fixed bug where useFindPaginated fetched non-existant pages

### DIFF
--- a/app/composables/useFindPaginated.ts
+++ b/app/composables/useFindPaginated.ts
@@ -69,7 +69,9 @@ export function useFindPaginated<T extends keyof EndpointToPaginatedTypeMap>(opt
 
   // Prefetch next page when data changes
   watch(data, () => {
-    if (!data.value || pageNo.value === lastPageNo.value ) return;
+    if (!data.value) return;
+    // Early return when there is no next page. This avoids 404 errors
+    if (data.value.count === 0 || pageNo.value === lastPageNo.value) return;
     const nextPageNo = pageNo.value + 1;
     queryClient.prefetchQuery({
       queryKey: [...queryKey, nextPageNo],


### PR DESCRIPTION
## Description

This PR fixes an issue with the `useFindPaginated` composable where it would cause a 404 error when attempting to prefetch a page of data where the next page didn't exist.

This was achieved by adding an additional check to the early return of the `watch` function where prefetching is handled:

```
    if (!data.value) return;
    // Early return when there is no next page. This avoids 404 errors
    if (data.value.count === 0 || pageNo.value === lastPageNo.value) return;
```

If there is no `data`, then no prefetching occurs. This appears to fix the problem in all the cases I tested.

## Related Issue

Closes #862 

## How was this tested?
- Spot checked on local Nuxt development server
- `npm run build` (build process completes without error)
- `npm run test` (all tests are passing)
