### PR TITLE
Fix prefetching of pages when there are no results (#862)

### DIFF
--- a/app/composables/useFindPaginated.ts
+++ b/app/composables/useFindPaginated.ts
@@ -64,18 +64,18 @@ export function useFindPaginated<T extends keyof EndpointToPaginatedTypeMap>(opt
   });
 
   const lastPageNo = computed(() => {
-    return data.value ? Math.ceil(data.value.count / unref(itemsPerPage)) : 1;
+    return data.value?.count ? Math.ceil(data.value.count / unref(itemsPerPage)) : 1;
   });
 
   // Prefetch next page when data changes
   watch(data, () => {
-    if (!data.value || pageNo.value === lastPageNo.value ) return;
+    if (!data.value || pageNo.value === lastPageNo.value) return;
     const nextPageNo = pageNo.value + 1;
     queryClient.prefetchQuery({
       queryKey: [...queryKey, nextPageNo],
       queryFn: () => findPaginated(createQueryParams(unref(nextPageNo))),
     });
-});
+  });
 
   // pagination controls
   const nextPage = () => {


### PR DESCRIPTION
## Description

When opening pages with 0 results, `lastPageNo` was set to 0. This made the condition `pageNo.value === lastPageNo.value` false, thus asking to fetch page 2 which resulted in a 404.
This fix ensures `lastPageNo` is always set to 1 or more, as there is never a page 0.
We also remove the redundant check for `!data.value` which might have originally been there to catch 0 results but should have been `!data.value?.count`.

## Related Issue

Closes #862

## How was this tested?

Manually for now. I wanted to discuss adding tests.

