### PR TITLE
[BUGFIX] Added MISC documents to useSourcesList defaults

### DIFF
--- a/app/composables/useSourcesList.ts
+++ b/app/composables/useSourcesList.ts
@@ -1,9 +1,11 @@
 import { computed, ref } from 'vue';
 
+const defaultSources = ['srd-2014', 'srd-2024', 'core', 'elderberry-inn-icons'];
+
 function loadSourcesFromLocalStorage(): string[] {
-  if (!import.meta.client) return []; // skip on server
+  if (!import.meta.client) return []; // skip on server (no lcoal storage)
   const saved_sources = localStorage.getItem('sources');
-  return saved_sources ? JSON.parse(saved_sources) : ['srd-2014', 'srd-2024'];
+  return saved_sources ? JSON.parse(saved_sources) : defaultSources;
 }
 
 function writeSourcesToLocalStorage(sourcesList: string[]) {
@@ -44,3 +46,4 @@ export const useSourcesList = () => ({
   setGameSystem,
   setSources,
 });
+


### PR DESCRIPTION
## Description

This PR addresses the issue of the Open5e misc always-on `Documents` not being included in the sources list on initial page load by adding them to the default sources in the `useSourcesList` composable

## Related Issue

Close #869

## How was this tested?
- Spot checked on local Nuxt development server
- `npm run build` (build process completes without error)
- `npm run test` (all tests green)
