### PR TITLE
refactor: move snakeToTitleCase to helpers

### DIFF
--- a/app/helpers/index.ts
+++ b/app/helpers/index.ts
@@ -2,6 +2,7 @@ export { formatModifier } from './formatModifier';
 export { formatSpellSubtitle } from './formatSpellSubtitle';
 export { sortDocumentsByPublisher } from './sortDocumentsByPublisher';
 export { parseChallengeRating } from './parseChallengeRating';
+export { snakeToTitleCase } from './snakeToTitleCase';
 export { titleCaseToKebabCase } from './titleCaseToKebabCase';
 
 export * from './resultsTableConfig';

--- a/app/helpers/snakeToTitleCase.ts
+++ b/app/helpers/snakeToTitleCase.ts
@@ -1,0 +1,17 @@
+/**
+ * Converts a snake_case string to Title Case
+ *
+ * @param {string} input - the snake_case string to convert
+ * @returns {string} - Title Case version
+ *
+ * @example
+ * snakeToTitleCase("bonus_actions") -> "Bonus Actions"
+ */
+
+export function snakeToTitleCase(input: string) {
+  return input
+    .toLowerCase()
+    .split('_')
+    .map(word => word[0].toUpperCase() + word.substring(1))
+    .join(' ');
+}

--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -272,7 +272,7 @@
 
 <script setup lang="ts">
 import type { CreatureAction } from '@/types';
-import { formatModifier } from '@/helpers';
+import { formatModifier, snakeToTitleCase } from '@/helpers';
 
 const rollDice = useDiceRoller();
 
@@ -330,13 +330,6 @@ const actions = computed(() => {
   return actionsByType;
 }) as ComputedRef<Record<ActionType, CreatureAction[]>>;
 
-// Converts SNAKE_CASE to Title Case, used for action type headers
-const snakeToTitleCase = (input: string) =>
-  input
-    .toLowerCase()
-    .split('_')
-    .map(word => word[0].toUpperCase() + word.substring(1))
-    .join(' ');
 
 // Format monster speeds for template
 const speeds = computed(() => {


### PR DESCRIPTION
## Summary

- Extracts the inline `snakeToTitleCase` function from `app/pages/monsters/[id].vue` (lines 334-339) into its own file at `app/helpers/snakeToTitleCase.ts`
- Re-exports from the helpers barrel (`app/helpers/index.ts`), consistent with existing string utilities like `titleCaseToKebabCase`
- Updates the monsters page to import from `@/helpers` instead of defining inline

## Test plan

- [x] Lint passes (pre-commit hook ran eslint --fix)
- [x] Function behavior is identical (same implementation, just moved)
- [ ] CI passes

Closes #880