### PR TITLE
[FEATURE] Add Open Graph / Twitter metadata

### DIFF
--- a/app/composables/useSeoEntry.ts
+++ b/app/composables/useSeoEntry.ts
@@ -1,0 +1,15 @@
+import type { Open5eData } from '@/types';
+
+export function useSeoEntry(data: Ref<Open5eData>) {
+	const url = useRequestURL();
+
+	watchEffect(() => {
+		if (!data.value) return;
+
+		useSeoMeta({
+			title: `${data.value.name} | Open5e`,
+			ogTitle: `${data.value.name} | Open5e`,
+			ogUrl: url.href,
+		});
+	});
+}

--- a/app/composables/useSeoIndex.ts
+++ b/app/composables/useSeoIndex.ts
@@ -1,0 +1,14 @@
+interface UseSeoIndexProps {
+  title: string
+};
+
+export function useSeoIndex(data: UseSeoIndexProps) {
+  const { title } = data;
+  const url = useRequestURL();
+
+  useSeoMeta({
+      title: `${title} | Open5e`,
+      ogTitle: `${title} | Open5e`,
+      ogUrl: url.href,
+  });
+}

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -90,9 +90,6 @@ const hideSidebars = () => {
   isEncounterVisible.value = false;
 };
 
-const url = useRequestURL();
-useSeoMeta({ ogUrl: url.href });
-
 </script>
 
 <style>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -90,6 +90,9 @@ const hideSidebars = () => {
   isEncounterVisible.value = false;
 };
 
+const url = useRequestURL();
+useSeoMeta({ ogUrl: url.href });
+
 </script>
 
 <style>

--- a/app/pages/backgrounds/[id].vue
+++ b/app/pages/backgrounds/[id].vue
@@ -76,7 +76,7 @@ const { data: background } = useFindOne(
   backgroundId,
 );
 
-usePageMetadata({ title: computed(() => background.value?.name) });
+useSeoMeta({ title: () => `${background.value?.name} | Open5e` });
 
 // sort benefits into different sections
 // different sections will be rendered to different parts of the page

--- a/app/pages/backgrounds/[id].vue
+++ b/app/pages/backgrounds/[id].vue
@@ -68,7 +68,7 @@
 </template>
 
 <script setup lang="ts">
-import type { BackgroundBenefit } from '~/types';
+import type { Background, BackgroundBenefit } from '@/types';
 
 const backgroundId = useQueryParameter('id');
 const { data: background } = useFindOne(
@@ -76,7 +76,7 @@ const { data: background } = useFindOne(
   backgroundId,
 );
 
-useSeoMeta({ title: () => `${background.value?.name} | Open5e` });
+useSeoEntry(background as Ref<Background>);
 
 // sort benefits into different sections
 // different sections will be rendered to different parts of the page

--- a/app/pages/backgrounds/index.vue
+++ b/app/pages/backgrounds/index.vue
@@ -39,6 +39,8 @@ import {
   backgroundTableColumnDefinitions
 } from '@/helpers/resultsTableConfig';
 
+useSeoIndex({ title: 'Backgrounds' });
+
 // Set up filters
 const filterState = useFilterState<{ name__icontains: string }>({
   key: 'backgrounds',

--- a/app/pages/classes/[className]/[subclass].vue
+++ b/app/pages/classes/[className]/[subclass].vue
@@ -50,7 +50,7 @@ const { data: subclassData } = useFindOne(API_ENDPOINTS.classes, subclassId,
   },
 );
 
-usePageMetadata({ title: computed(() => subclassData.value?.name) });
+useSeoMeta({ title: () => `${subclassData.value?.name} | Open5e` });
 
 const features = computed(() => {
   const features = subclassData.value?.features;

--- a/app/pages/classes/[className]/[subclass].vue
+++ b/app/pages/classes/[className]/[subclass].vue
@@ -38,6 +38,8 @@
 </template>
 
 <script setup lang="ts">
+import type { Class } from '@/types';
+
 const subclassId = useQueryParameter('subclass');
 const baseClassId = useQueryParameter('className');
 const { data: subclassData } = useFindOne(API_ENDPOINTS.classes, subclassId,
@@ -50,8 +52,9 @@ const { data: subclassData } = useFindOne(API_ENDPOINTS.classes, subclassId,
   },
 );
 
-useSeoMeta({ title: () => `${subclassData.value?.name} | Open5e` });
+useSeoEntry(subclassData as Ref<Class>);
 
+useBreadcrumbs();
 const features = computed(() => {
   const features = subclassData.value?.features;
   if (!features) return [];

--- a/app/pages/classes/[className]/index.vue
+++ b/app/pages/classes/[className]/index.vue
@@ -136,7 +136,7 @@ const { data: classData } = useFindOne(API_ENDPOINTS.classes, classId,
   },
 );
 
-usePageMetadata({ title: computed(() => classData.value?.name) });
+useSeoMeta({ title: () => `${classData.value?.name} | Open5e` });
 
 // fetch subclasses to generate links
 const { data: subclasses } = useFindMany(API_ENDPOINTS.classes, {

--- a/app/pages/classes/[className]/index.vue
+++ b/app/pages/classes/[className]/index.vue
@@ -122,7 +122,7 @@
 </template>
 
 <script setup lang="ts">
-import type { ClassFeature } from '@/types';
+import type { ClassFeature, Class } from '@/types';
 import { titleCaseToKebabCase } from '@/helpers';
 
 const classId = useQueryParameter('className');
@@ -136,7 +136,7 @@ const { data: classData } = useFindOne(API_ENDPOINTS.classes, classId,
   },
 );
 
-useSeoMeta({ title: () => `${classData.value?.name} | Open5e` });
+useSeoEntry(classData as Ref<Class>);
 
 // fetch subclasses to generate links
 const { data: subclasses } = useFindMany(API_ENDPOINTS.classes, {

--- a/app/pages/classes/index.vue
+++ b/app/pages/classes/index.vue
@@ -40,6 +40,8 @@ import {
   classTableColumnDefinitions,
 } from '@/helpers/resultsTableConfig';
 
+useSeoIndex({ title: 'Classes'});
+
 // Set up filters
 const filterState = useFilterState<{ name__contains: string }>({
   key: 'classes',

--- a/app/pages/conditions/[id].vue
+++ b/app/pages/conditions/[id].vue
@@ -39,6 +39,8 @@
 </template>
 
 <script setup lang="ts">
+import type { Condition } from '@/types';
+
 const conditionId = useQueryParameter('id');
 const { data: condition } = useFindOne(API_ENDPOINTS.conditions, conditionId,
   { 
@@ -49,7 +51,7 @@ const { data: condition } = useFindOne(API_ENDPOINTS.conditions, conditionId,
   },
 );
 
-useSeoMeta({ title: () => `${condition.value?.name} | Open5e` });
+useSeoEntry(condition as Ref<Condition>);
 
 // generate source key from page URL - for use with source-tab cmpnt
 const sourceKey = computed(() => {

--- a/app/pages/conditions/[id].vue
+++ b/app/pages/conditions/[id].vue
@@ -49,7 +49,7 @@ const { data: condition } = useFindOne(API_ENDPOINTS.conditions, conditionId,
   },
 );
 
-usePageMetadata({ title: computed(() => condition.value?.name) });
+useSeoMeta({ title: () => `${condition.value?.name} | Open5e` });
 
 // generate source key from page URL - for use with source-tab cmpnt
 const sourceKey = computed(() => {

--- a/app/pages/conditions/index.vue
+++ b/app/pages/conditions/index.vue
@@ -39,6 +39,8 @@ import {
   conditionTableColumnDefinitions,
 } from '@/helpers/resultsTableConfig';
 
+useSeoIndex({ title: 'Conditions' });
+
 // Set up filters
 const filterState = useFilterState<{ name__contains: string }>({
   key: 'conditions',

--- a/app/pages/equipment/[id].vue
+++ b/app/pages/equipment/[id].vue
@@ -115,13 +115,13 @@
 </template>
 
 <script setup lang="ts">
-import type { WeaponSummary } from '@/types';
+import type { Item, WeaponSummary } from '@/types';
 
 const itemId = useQueryParameter('id');
 const params = { 'is_magic_item': 'false' };
 const { data: item } = useFindOne(API_ENDPOINTS.equipment, itemId, { params });
 
-useSeoMeta({ title: () => `${item.value?.name} | Open5e` });
+useSeoEntry(item as Ref<Item>);
 
 const formatCost = (input: string) => {
   if (!input) return '';

--- a/app/pages/equipment/[id].vue
+++ b/app/pages/equipment/[id].vue
@@ -121,7 +121,7 @@ const itemId = useQueryParameter('id');
 const params = { 'is_magic_item': 'false' };
 const { data: item } = useFindOne(API_ENDPOINTS.equipment, itemId, { params });
 
-usePageMetadata({ title: computed(() => item.value?.name) });
+useSeoMeta({ title: () => `${item.value?.name} | Open5e` });
 
 const formatCost = (input: string) => {
   if (!input) return '';

--- a/app/pages/equipment/index.vue
+++ b/app/pages/equipment/index.vue
@@ -43,6 +43,8 @@ import {
   equipmentApiParams
 } from '@/helpers/resultsTableConfig';
 
+useSeoIndex({ title: 'Equipment' });
+
 // Set up filters
 const filterState = useFilterState<{ name__icontains: string }>({
   key: 'equipment',

--- a/app/pages/feats/[id].vue
+++ b/app/pages/feats/[id].vue
@@ -31,6 +31,8 @@
 </template>
 
 <script setup lang="ts">
+import type { Feat } from '~/types';
+
 const featId = useQueryParameter('id');
 const { data: feat } = useFindOne(API_ENDPOINTS.feats, featId, {
   params: {
@@ -38,7 +40,7 @@ const { data: feat } = useFindOne(API_ENDPOINTS.feats, featId, {
   },
 });
 
-useSeoMeta({ title: () => `${feat.value?.name} | Open5e` });
+useSeoEntry(feat as Ref<Feat>);
 
 // generate source key from page URL - for use with source-tag cmpnt
 const sourceKey = computed(() => {

--- a/app/pages/feats/[id].vue
+++ b/app/pages/feats/[id].vue
@@ -38,7 +38,7 @@ const { data: feat } = useFindOne(API_ENDPOINTS.feats, featId, {
   },
 });
 
-usePageMetadata({ title: computed(() => feat.value?.name) });
+useSeoMeta({ title: () => `${feat.value?.name} | Open5e` });
 
 // generate source key from page URL - for use with source-tag cmpnt
 const sourceKey = computed(() => {

--- a/app/pages/feats/index.vue
+++ b/app/pages/feats/index.vue
@@ -39,6 +39,8 @@ import {
   featTableColumnDefinitions,
 } from '@/helpers/resultsTableConfig';
 
+useSeoIndex({ title: 'Feats' });
+
 // Set up filters
 const filterState = useFilterState<{ name__icontains: string }>({
   key: 'feats',

--- a/app/pages/legal/[id].vue
+++ b/app/pages/legal/[id].vue
@@ -8,5 +8,5 @@
 <script setup lang="ts">
 const licenseId = useQueryParameter('id');
 const { data: license } = useFindOne(API_ENDPOINTS.licenses, licenseId);
-usePageMetadata({ title: computed(() => license.value?.name) });
+useSeoMeta({ title: () => `${license.value?.name} | Open5e` });
 </script>

--- a/app/pages/legal/[id].vue
+++ b/app/pages/legal/[id].vue
@@ -6,7 +6,10 @@
 </template>
 
 <script setup lang="ts">
+import type { License } from '@/types';
+
 const licenseId = useQueryParameter('id');
 const { data: license } = useFindOne(API_ENDPOINTS.licenses, licenseId);
-useSeoMeta({ title: () => `${license.value?.name} | Open5e` });
+
+useSeoEntry(license as Ref<License>);
 </script>

--- a/app/pages/legal/index.vue
+++ b/app/pages/legal/index.vue
@@ -20,9 +20,12 @@
 
 <script setup lang="ts">
 import type { License } from '@/types';
+
 const { data } = useFindMany(API_ENDPOINTS.licenses, {
   fields: ['name', 'key'].join(',')
 });
+
+useSeoIndex({ title: 'Legal Information' });
 
 const licenses = data as Ref<License[]>;
 </script>

--- a/app/pages/magic-items/[id].vue
+++ b/app/pages/magic-items/[id].vue
@@ -38,5 +38,5 @@
 <script setup lang="ts">
 const itemId = useQueryParameter('id');
 const { data: item } = useFindOne(API_ENDPOINTS.magicitems, itemId);
-usePageMetadata({ title: computed(() => item.value?.name) });
+useSeoMeta({ title: () => `${item.value?.name} | Open5e` });
 </script>

--- a/app/pages/magic-items/[id].vue
+++ b/app/pages/magic-items/[id].vue
@@ -36,7 +36,10 @@
 </template>
 
 <script setup lang="ts">
+import type { MagicItem } from '@/types';
+
 const itemId = useQueryParameter('id');
 const { data: item } = useFindOne(API_ENDPOINTS.magicitems, itemId);
-useSeoMeta({ title: () => `${item.value?.name} | Open5e` });
+
+useSeoEntry(item as Ref<MagicItem>);
 </script>

--- a/app/pages/magic-items/index.vue
+++ b/app/pages/magic-items/index.vue
@@ -46,6 +46,8 @@ import {
   magicItemTableColumnDefinitions,
 } from '@/helpers/resultsTableConfig';
 
+useSeoIndex({ title: 'Magic Items' });
+
 // Set up filters
 const filterState = useFilterState<MagicItemFilterState>({
   key: 'magicItems',

--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -288,7 +288,7 @@ const { data: monster } = useFindOne(
   { params },
 );
 
-usePageMetadata({ title: computed(() => monster.value?.name) });
+useSeoMeta({ title: () => `${monster.value?.name} | Open5e` });
 
 // Calculate initiative bonus from dexterity modifier if not explicitly set
 const initiativeBonus = computed(() => {

--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -271,7 +271,7 @@
 </template>
 
 <script setup lang="ts">
-import type { CreatureAction } from '@/types';
+import type { Creature, CreatureAction } from '@/types';
 import { formatModifier } from '@/helpers';
 
 const rollDice = useDiceRoller();
@@ -288,7 +288,7 @@ const { data: monster } = useFindOne(
   { params },
 );
 
-useSeoMeta({ title: () => `${monster.value?.name} | Open5e` });
+useSeoEntry(monster as Ref<Creature>);
 
 // Calculate initiative bonus from dexterity modifier if not explicitly set
 const initiativeBonus = computed(() => {

--- a/app/pages/monsters/index.vue
+++ b/app/pages/monsters/index.vue
@@ -52,6 +52,8 @@ import {
   monsterFilterDefaults,
 } from '@/helpers/resultsTableConfig';
 
+useSeoIndex({ title: 'Monsters' });
+
 const filterState = useFilterState<MonsterFilterState>({
   key: 'monsters',
   fields: monsterFilterDefaults,

--- a/app/pages/rules/[id].vue
+++ b/app/pages/rules/[id].vue
@@ -16,8 +16,9 @@
 </template>
 
 <script setup lang="ts">
+import type { RuleSet } from '@/types';
 const ruleId = useQueryParameter('id');
 const { data: ruleset } = useFindOne(API_ENDPOINTS.rules, ruleId);
-usePageMetadata({ title: computed(() => ruleset.value?.name) });
 
+useSeoEntry(ruleset as Ref<RuleSet>);
 </script>

--- a/app/pages/rules/index.vue
+++ b/app/pages/rules/index.vue
@@ -39,6 +39,8 @@ import {
   rulesTableColumnDefinitions,
 } from '@/helpers/resultsTableConfig';
 
+useSeoIndex({ title: 'Rules' });
+
 // Set up filters
 const filterState = useFilterState<{ name__contains: string }>({
   key: 'rules',

--- a/app/pages/search/index.vue
+++ b/app/pages/search/index.vue
@@ -68,6 +68,8 @@
 <script setup lang="ts">
 import type { SearchResult } from '~/types';
 
+useSeoIndex({ title: 'Search' });
+
 const searchText = useReactiveQueryParam('text');
 const { data } = useSearch(searchText);
 const { sources } = useSourcesList();

--- a/app/pages/sources/[id].vue
+++ b/app/pages/sources/[id].vue
@@ -39,9 +39,11 @@
 </template>
 
 <script setup lang="ts">
+import type { Document } from '@/types';
+
 const documentId = useQueryParameter('id');
 const { data: document } = useFindOne(API_ENDPOINTS.documents, documentId);
 
-usePageMetadata({ title: computed(() => document.value?.name) });
+useSeoEntry(document as Ref<Document>);
 
 </script>

--- a/app/pages/sources/index.vue
+++ b/app/pages/sources/index.vue
@@ -46,4 +46,5 @@
 import type { Document } from '@/types';
 import { sortDocumentsByPublisher } from '@/helpers';
 const { data: documents } = useDocuments();
+useSeoIndex({ title: 'Documents' });
 </script>

--- a/app/pages/species/[id].vue
+++ b/app/pages/species/[id].vue
@@ -71,13 +71,14 @@
 </template>
 
 <script setup lang="ts">
+import type { Species } from '~/types';
+
 const speciesId = useQueryParameter('id');
 const { data: species } = useFindOne(API_ENDPOINTS.species, speciesId, {
   params: { subspecies_of__isnull: 'true' },
 });
 
-usePageMetadata({ title: computed(() => species.value?.name) });
-
+useSeoEntry(species as Ref<Species>);
 
 const { data: subspecies } = useFindMany(API_ENDPOINTS.species, {
   subspecies_of__key__in: speciesId,

--- a/app/pages/species/index.vue
+++ b/app/pages/species/index.vue
@@ -36,6 +36,8 @@
 <script setup lang="ts">
 import { speciesApiParams, speciesTableColumnDefinitions } from '@/helpers';
 
+useSeoIndex({ title: 'Species' });
+
 // Set up filters
 const filterState = useFilterState<{ name__icontains: string }>({
   key: 'species',

--- a/app/pages/spells/[id].vue
+++ b/app/pages/spells/[id].vue
@@ -83,7 +83,7 @@ import type { Spell } from '@/types';
 const spellId = useQueryParameter('id'); 
 const { data: spell } = useFindOne(API_ENDPOINTS.spells, spellId);
 
-usePageMetadata({ title: computed(() => spell.value?.name) });
+useSeoEntry(spell as Ref<Spell>);
 
 function formatCastingTime(spell: Spell) {
   const { casting_time, reaction_condition } = spell;

--- a/app/pages/spells/index.vue
+++ b/app/pages/spells/index.vue
@@ -46,6 +46,8 @@ import {
   spellTableColumnDefinitions,
 } from '@/helpers/resultsTableConfig';
 
+useSeoIndex({ title: 'Spells' });
+
 // Set up filters
 const filterState = useFilterState<SpellFilterState>({
   key: 'spells',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -16,11 +16,23 @@ export default defineNuxtConfig({
       meta: [
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-        {
-          key: 'description',
-          name: 'description',
-          content: 'The truly open source for 5e rules and resources',
-        },
+        { key: 'description', name: 'description', content: 'Free and open-source library of 5e rules, monsters, spells, etc. Powered by the Open5e API' },
+        
+        // Open Graph metadata
+        { property: 'og:title', content: 'Open5e'},
+        { property: 'og:site:name', content: 'Open5e' },
+        { property: 'og:description', content: 'Free and open-source library of 5e rules, monsters, spells, etc. Powered by the Open5e API'},
+        { property: 'og:type', content: 'website' },
+        { property: 'og:url', content: 'https://open5e.com' },
+        { property: 'og:image', content: 'https://open5e.com/img/logo.png'},
+        { property: 'og:image:width', content: '200' },
+        { property: 'og:image:height', content: '200' },
+
+        // Twitter metadata
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:title', content: 'Open5e' },
+        { name: 'twitter:description', content: 'Free and open-source library of 5e rules, monsters, spells, etc. Powered by the Open5e API' },
+        { name: 'twitter:image', content: 'https://open5e.com/img/logo.png'} 
       ],
       link: [
         { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },


### PR DESCRIPTION
## Description

This PR adds missing Open Graph and Twitter metadata to the Open5e website. This is to prettify social media embeds and shares in anticipation of an uptick (relatively speaking) of social media shares when V2 releases.

The changes to the Nuxt config represent the base metadata configuration. The changes to the base layout handle the generation of dynamic URL metadata. Changes to single-view dynamic pages are opt-in overwrites. 


**N.B.** The card image will not work correctly until we release. The URL for the image points location of the Open5e logo on live website, but as this URL changed from v1->v2 it will not be valid until we make the cut over.

## Related Issue

Closes #882

## How was this tested?
- `npm run build` (build process completes without error)
- `npm run test` (all tests green)
