### PR TITLE
[BUGFIX] Monster illustrations on `/monster/[id]`

### DIFF
--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -25,30 +25,31 @@
       </div>
     </div>
 
-    <img
-      v-if="monster.illustration"
-      :src="monster.illustration.file_url"
-      :alt="monster.illustration.alt_text"
-      class="img-main"
-    />
-    <p class="italic">
+    <p class="mt-0 italic">
       <span>{{ `${monster.size.name} ${monster.type.name}` }}</span>
-
+      
       <span v-if="monster.subcategory">
         {{ ' ' + `(${monster.subcategory})` }}
       </span>
-
+      
       <span v-if="monster.alignment">
         {{ ', ' + monster.alignment }}
       </span>
       
       <span>{{ ' ' }}</span>
-
+      
       <SourceTag
-        :title="monster.document.name"
+      :title="monster.document.name"
         :text="monster.document.key"
       />
     </p>
+
+    <img
+      v-if="monster.illustration"
+      :src="illustrationUrl"
+      :alt="monster.illustration.alt_text"
+      class="bg-fog  p-2"
+    />
 
     <table class="table-auto border-none text-base">
       <tbody class="[&>*>*]:border-none [&>*]:border-none">
@@ -338,6 +339,11 @@ const snakeToTitleCase = (input: string) =>
     .map(word => word[0].toUpperCase() + word.substring(1))
     .join(' ');
 
+const illustrationUrl = computed(() => {
+  if (!monster.value?.illustration) return;
+  return useRuntimeConfig().public.apiUrl + monster.value.illustration.file_url;
+});
+
 // Format monster speeds for template
 const speeds = computed(() => {
   if (!monster?.value?.speed) return '';
@@ -417,18 +423,3 @@ const removeFromEncounter = () => {
   encounterStore.removeMonster(monster.value.key);
 };
 </script>
-
-<style scoped lang="scss">
-.img-main {
-  float: right;
-  width: 30%;
-  min-width: 300px;
-}
-
-@media screen and (max-width: 600px) {
-  .img-main {
-    float: none;
-    width: 100%;
-  }
-}
-</style>

--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -48,7 +48,7 @@
       v-if="monster.illustration"
       :src="illustrationUrl"
       :alt="monster.illustration.alt_text"
-      class="bg-fog  p-2"
+      class="w-full max-w-[720px] bg-fog p-2"
     />
 
     <table class="table-auto border-none text-base">


### PR DESCRIPTION
## Description

This PR closes an issue where illustrations on the `/monsters/[id]` page were not being rendered.

The error was due to the URL for the image source not being correctly configured to point to the API, this has been fixed.

<img width="1250" height="1025" alt="Screenshot from 2026-04-07 20-08-20" src="https://github.com/user-attachments/assets/f01af904-e179-4a38-a7f4-818c885b7210" />

## Related Issue

Closes #884 

## How was this tested?
- Spot checked on local Nuxt development server
- `npm run build`
- `npm run test`