### PR TITLE
[QA /  BUGFIX] Fix Discord link on home page

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -55,25 +55,23 @@
     <p>
       <b>VueJs UI layer.</b> A Vue.js single-page app, using the Nuxt framework.
     </p>
-
-    <a
-      href="https://github.com/open5e/open5e"
-      class="external-button mr-2"
-    >
-      <img
-        src="/img/github-website-button.png"
-        alt="Open5e site repo"
-      />
-    </a>
-    <a
-      href="https://github.com/open5e/open5e-api"
-      class="external-button"
-    >
-      <img
-        src="/img/github-api-button.png"
-        alt="Open5e API Repo"
-      />
-    </a>
+    <div class="flex">
+      <a
+        href="https://github.com/open5e/open5e"
+        class="mr-2 flex w-48 hover:opacity-90"
+      >
+        <img src="/img/github-website-button.png" alt="Open5e site repo" />
+      </a>
+      <a
+        href="https://github.com/open5e/open5e-api"
+        class="flex w-48 hover:opacity-90"
+      >
+        <img
+          src="/img/github-api-button.png"
+          alt="Open5e API Repo"
+        />
+      </a>
+    </div>
 
     <h3>Support us on Patreon</h3>
     <p>
@@ -83,7 +81,7 @@
     </p>
     <a
       href="https://www.patreon.com/open5e"
-      class="external-button"
+      class="flex w-48 hover:opacity-90"
     >
       <img
         class="rounded-lg"
@@ -99,7 +97,7 @@
     </p>
     <a
       href="https://discord.gg/QXqF6gSVqB"
-      class="external-button"
+      class="flex w-48 hover:opacity-90"
     >
       <img
         src="/img/discord-button.png"
@@ -124,15 +122,3 @@
     </p>
   </section>
 </template>
-
-<style lang="scss">
-.external-button {
-  margin-top: 0.6rem;
-  zoom: 40%;
-  display: inline-block;
-
-  &:hover {
-    opacity: 0.9;
-  }
-}
-</style>


### PR DESCRIPTION
## Description

This PR fixes a small visual bug identified during QC for the release of V2.

On the home page the link to our Discord was appearing inline with the **The API** heading.

<img width="993" height="1024" alt="Screenshot from 2026-04-08 12-30-55" src="https://github.com/user-attachments/assets/d49f2904-a123-421b-9819-5f08b36fba0f" />

After a few changes, migrating a little SCSS to TailwindCSS, as is appearing as it should:


<img width="959" height="685" alt="Screenshot from 2026-04-08 13-05-59" src="https://github.com/user-attachments/assets/534645fb-92be-4711-8184-6da131feee33" />