### PR TITLE
[QA / PATCH] Update front-end to use `"challenge_rating"` Creature field

### DIFF
--- a/app/components/EncounterBuilder.vue
+++ b/app/components/EncounterBuilder.vue
@@ -68,7 +68,7 @@
           </nuxt-link>
           <div class="text-sm text-gray-500 dark:text-gray-300">
             CR
-            {{ monster.challenge_rating || monster.challenge_rating }} ({{
+            {{ parseChallengeRating(monster.challenge_rating) }} ({{
               (monster.experience_points ?? 0) * monster.count
             }}
             XP)
@@ -172,6 +172,7 @@
 
 <script setup lang="ts">
 import EncounterBuilderMonsterSearch from '~/components/EncounterBuilderMonsterSearch.vue';
+import { parseChallengeRating } from '~/helpers';
 import type { Monster } from '~/types/monster';
 // Prop included for testing purposes
 defineProps<{ isLoadingOverride?: boolean }>();

--- a/app/components/EncounterBuilder.vue
+++ b/app/components/EncounterBuilder.vue
@@ -221,8 +221,7 @@ const handleMonsterSelect = (monster: Monster) => {
   encounterStore.addMonster(
     monster.key,
     monster.name,
-    monster.challenge_rating_decimal,
-    monster.challenge_rating,
+    monster.challenge_rating
   );
 };
 </script>

--- a/app/components/EncounterBuilderAddButton.vue
+++ b/app/components/EncounterBuilderAddButton.vue
@@ -21,6 +21,7 @@
 <script lang="ts" setup>
 import type { Monster } from '@/types';
 import { PlusIcon, MinusIcon } from '@heroicons/vue/24/solid';
+import { parseChallengeRating } from '~/helpers';
 
 const props = defineProps<{ monster: Monster }>();
 const encounterStore = useEncounterStore();
@@ -33,8 +34,8 @@ const addToEncounter = () => {
   encounterStore.addMonster(
     props.monster.key,
     props.monster.name,
-    parseFloat(props.monster.challenge_rating_decimal),
-    props.monster.challenge_rating_text
+    parseFloat(props.monster.challenge_rating),
+    parseChallengeRating(props.monster.challenge_rating)
   );
 };
 

--- a/app/components/EncounterBuilderAddButton.vue
+++ b/app/components/EncounterBuilderAddButton.vue
@@ -21,7 +21,6 @@
 <script lang="ts" setup>
 import type { Monster } from '@/types';
 import { PlusIcon, MinusIcon } from '@heroicons/vue/24/solid';
-import { parseChallengeRating } from '~/helpers';
 
 const props = defineProps<{ monster: Monster }>();
 const encounterStore = useEncounterStore();
@@ -34,8 +33,7 @@ const addToEncounter = () => {
   encounterStore.addMonster(
     props.monster.key,
     props.monster.name,
-    parseFloat(props.monster.challenge_rating),
-    parseChallengeRating(props.monster.challenge_rating)
+    parseFloat(props.monster.challenge_rating)
   );
 };
 

--- a/app/components/EncounterBuilderMonsterSearch.vue
+++ b/app/components/EncounterBuilderMonsterSearch.vue
@@ -83,6 +83,7 @@ import {
 } from '@headlessui/vue';
 import type { Monster } from '~/types/monster';
 import type { Creature } from '@/types';
+import { parseChallengeRating } from '~/helpers';
 const emit = defineEmits<{
   (e: 'select', monster: Monster): void;
 }>();
@@ -105,10 +106,8 @@ const mapMonsterFromAPI = (monster: Creature): Monster => {
   const base = {
     key: String(monster.key),
     name: String(monster.name) || '',
-    challenge_rating: String(
-      monster.challenge_rating_text || '0'
-    ),
-    challenge_rating_decimal: Number(monster.challenge_rating_decimal) || 0,
+    challenge_rating: String(parseChallengeRating(monster.challenge_rating) || '0'),
+    challenge_rating_decimal: Number(monster.challenge_rating) || 0,
   };
 
   return !monster.document

--- a/app/components/EncounterBuilderMonsterSearch.vue
+++ b/app/components/EncounterBuilderMonsterSearch.vue
@@ -53,7 +53,7 @@
               />
             </div>
             <span :class="[active ? 'text-white' : 'text-gray-500']">
-              CR {{ monster.challenge_rating }}
+              CR {{ parseChallengeRating(monster.challenge_rating) }}
             </span>
           </li>
         </ComboboxOption>
@@ -106,8 +106,7 @@ const mapMonsterFromAPI = (monster: Creature): Monster => {
   const base = {
     key: String(monster.key),
     name: String(monster.name) || '',
-    challenge_rating: String(parseChallengeRating(monster.challenge_rating) || '0'),
-    challenge_rating_decimal: Number(monster.challenge_rating) || 0,
+    challenge_rating: Number(monster.challenge_rating) || 0,
   };
 
   return !monster.document

--- a/app/composables/useEncounter.ts
+++ b/app/composables/useEncounter.ts
@@ -3,7 +3,7 @@ import { useLocalStorage } from '@vueuse/core';
 import { API_ENDPOINTS, useAPI } from '~/composables/api';
 import { usePartyStore } from '~/composables/useParty';
 import { useXPCalculator } from '~/composables/useXPCalculator';
-import type { Monster } from '~/types/monster';
+import type { Monster } from '@/types/monster';
 
 interface EncounterMonster extends Monster {
   count: number;
@@ -107,13 +107,12 @@ export const useEncounterStore = () => {
       const monster = monsters.value.find(m => m.key === key);
       if (monster) {
         // Preserve the count and basic info while updating with API data
-        const { count, name, challenge_rating_decimal, challenge_rating }
+        const { count, name, challenge_rating }
           = monster;
         Object.assign(monster, data, {
           count,
           name,
-          challenge_rating_decimal,
-          challenge_rating_text: challenge_rating,
+          challenge_rating,
         });
       }
 
@@ -127,8 +126,7 @@ export const useEncounterStore = () => {
   const addMonster = async (
     key: string,
     name: string,
-    challenge_rating_decimal: number,
-    challenge_rating_text: string,
+    challenge_rating: number,
   ) => {
     try {
       // First check if monster exists
@@ -142,8 +140,7 @@ export const useEncounterStore = () => {
       monsters.value.push({
         key,
         name,
-        challenge_rating_decimal,
-        challenge_rating: challenge_rating_text,
+        challenge_rating,
         count: 1,
         document: {
           name: 'Loading...',

--- a/app/helpers/resultsTableConfig/monsters.ts
+++ b/app/helpers/resultsTableConfig/monsters.ts
@@ -18,7 +18,7 @@ export const monsterApiParams = {
     'key',
     'name',
     'document',
-    'challenge_rating_decimal',
+    'challenge_rating',
     'type',
     'size',
   ].join(','),
@@ -37,8 +37,8 @@ export const monsterTableColumnDefinitions: TableColumn<Monster>[] = [
   },
   {
     displayName: 'CR',
-    value: (data) => parseChallengeRating(data.challenge_rating_decimal),
-    sortValue: 'challenge_rating_decimal',
+    value: (data) => parseChallengeRating(data.challenge_rating),
+    sortValue: 'challenge_rating',
   },
   {
     displayName: 'Type',
@@ -74,7 +74,7 @@ export const monsterFilterSelectFieldsDefinition: ResultTableSelectFieldFilter[]
   },
   {
     name: 'CR (min)',
-    filterField: 'challenge_rating_decimal__gte',
+    filterField: 'challenge_rating__gte',
     options: monsterChallengeRatings.map(([name, value]) => ({
       name: name,
       value: value.toString(),
@@ -82,7 +82,7 @@ export const monsterFilterSelectFieldsDefinition: ResultTableSelectFieldFilter[]
   },
   {
     name: 'CR (max)',
-    filterField: 'challenge_rating_decimal__lte',
+    filterField: 'challenge_rating__lte',
     options: monsterChallengeRatings.map(([name, value]) => ({
       name: name,
       value: value.toString(),
@@ -92,8 +92,8 @@ export const monsterFilterSelectFieldsDefinition: ResultTableSelectFieldFilter[]
 
 export const monsterFilterDefaults: Readonly<MonsterFilterState> = {
   name__icontains: '',
-  challenge_rating_decimal_gte: '',
-  challenge_rating_decimal__lte: '',
+  challenge_rating__gte: '',
+  challenge_rating__lte: '',
   size: '',
   type: '',
 };

--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -165,7 +165,7 @@
         <tr class="grid grid-cols-[10rem,_1fr] [&>*]:p-0">
           <th>Challenge</th>
           <td class="text-nowrap">
-            <span>{{ monster.challenge_rating_text + " " }}</span>
+            <span>{{ parseChallengeRating(monster.challenge_rating) + " " }}</span>
             <span>{{ `(${monster.experience_points.toLocaleString()} XP)` }}</span>
           </td>
         </tr>
@@ -273,7 +273,7 @@
 
 <script setup lang="ts">
 import type { Creature, CreatureAction } from '@/types';
-import { formatModifier, snakeToTitleCase } from '@/helpers';
+import { formatModifier, snakeToTitleCase, parseChallengeRating } from '@/helpers';
 
 const rollDice = useDiceRoller();
 
@@ -401,8 +401,8 @@ const addToEncounter = () => {
   encounterStore.addMonster(
     monster.value.key,
     monster.value.name,
-    parseFloat(monster.value.challenge_rating_decimal),
-    monster.value.challenge_rating_text,
+    parseFloat(monster.value.challenge_rating),
+    parseChallengeRating(monster.value.challenge_rating),
   );
 };
 

--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -402,7 +402,6 @@ const addToEncounter = () => {
     monster.value.key,
     monster.value.name,
     parseFloat(monster.value.challenge_rating),
-    parseChallengeRating(monster.value.challenge_rating),
   );
 };
 

--- a/app/types/filters.ts
+++ b/app/types/filters.ts
@@ -7,8 +7,8 @@ export type MagicItemFilterState = {
 
 export type MonsterFilterState = {
   name__icontains?: string;
-  challenge_rating_decimal_gte?: string;
-  challenge_rating_decimal__lte?: string;
+  challenge_rating__gte?: string;
+  challenge_rating__lte?: string;
   size?: string;
   type?: string;
 };

--- a/app/types/monster.ts
+++ b/app/types/monster.ts
@@ -1,8 +1,7 @@
 export interface Monster {
   key: string;
   name: string;
-  challenge_rating: string;
-  challenge_rating_decimal: number;
+  challenge_rating: number;
   document?: {
     name: string;
     key: string;

--- a/app/types/open5e-api.ts
+++ b/app/types/open5e-api.ts
@@ -1775,8 +1775,7 @@ export interface components {
              * Format: decimal
              * @description Challenge Rating field as a decimal number.
              */
-            challenge_rating_decimal: string;
-            readonly challenge_rating_text: string;
+            challenge_rating: string;
             /**
              * Format: int64
              * @description The Creauture's Proficiency Bonus
@@ -4494,11 +4493,11 @@ export interface operations {
                 subcategory__iexact?: string;
                 /** @description Unique key for the Item. */
                 type?: string;
-                challenge_rating_decimal?: number;
-                challenge_rating_decimal__lt?: number;
-                challenge_rating_decimal__lte?: number;
-                challenge_rating_decimal__gt?: number;
-                challenge_rating_decimal__gte?: number;
+                challenge_rating?: number;
+                challenge_rating__lt?: number;
+                challenge_rating__lte?: number;
+                challenge_rating__gt?: number;
+                challenge_rating__gte?: number;
                 armor_class?: number;
                 armor_class__lt?: number;
                 armor_class__lte?: number;

--- a/tests/unit/components/EncounterBuilder.test.tsx
+++ b/tests/unit/components/EncounterBuilder.test.tsx
@@ -7,8 +7,7 @@ interface MockMonster {
   key: string;
   name: string;
   count: number;
-  challenge_rating_decimal: number;
-  challenge_rating_text: string;
+  challenge_rating: number;
   document?: {
     name: string;
     key: string;
@@ -97,8 +96,7 @@ describe('EncounterBuilder', () => {
     const testMonster = {
       key: 'test-monster',
       name: 'Test Monster',
-      challenge_rating_decimal: 1,
-      challenge_rating: '1',
+      challenge_rating: 1,
     };
 
     await wrapper
@@ -109,7 +107,6 @@ describe('EncounterBuilder', () => {
       'test-monster',
       'Test Monster',
       1,
-      '1',
     );
   });
 
@@ -120,8 +117,7 @@ describe('EncounterBuilder', () => {
         key: 'test-monster',
         name: 'Test Monster',
         count: 1,
-        challenge_rating_decimal: 1,
-        challenge_rating_text: '1',
+        challenge_rating: 1,
         document: {
           name: 'Test Document',
           key: 'test',

--- a/tests/unit/pages/monster.test.tsx
+++ b/tests/unit/pages/monster.test.tsx
@@ -47,8 +47,7 @@ mockNuxtImport('useFindOne', () => {
         key: 'small',
         url: 'http://localhost:8000/v2/sizes/small/',
       },
-      challenge_rating_decimal: '0.250',
-      challenge_rating_text: '1/4',
+      challenge_rating: '0.250',
       speed: {
         walk: 30.0,
         unit: 'feet',


### PR DESCRIPTION
## Description

**N.B. This PR will fail CI/CD until the changes to the API it depends on are merged to `staging`**

This PR updates the front-end website to correctly consume the updated `"challenge_rating"` field of the `/v2/creautres` endpoint. This field replaces the `"challenge_rating_text"` and `"challenge_rating_decimal"` fields, which unnecessarily duplicated information.

In situations where a textual representation of CR is required, the existing `parseChallengeRating()` helper function was used instead

## Related Issue

Addresses changes proposed in issue https://github.com/open5e/open5e-api/issues/902 and implemented in PR https://github.com/open5e/open5e-api/pull/910

## How was this tested?
This PR was tested on a local Nuxt development server pulling data from a local Django development server running the feature branch https://github.com/open5e/open5e-api/pull/910

In this setup, the following tests were run:
- Spot checking website
- `npm run test` (all tests green)
- `npm run build` (build process completes without error)