### PR TITLE
Provide search link from the 404 page (#863)

### DIFF
--- a/app/composables/api.ts
+++ b/app/composables/api.ts
@@ -74,15 +74,11 @@ export interface EndpointToPaginatedTypeMap {
 export type ExtractItemType<T> = T extends { results: (infer U)[] } ? U : never;
 
 // convenience type to get item type from endpoint key
-export type ExtractPaginatedItemType<T extends keyof EndpointToPaginatedTypeMap> = 
+export type ExtractPaginatedItemType<T extends keyof EndpointToPaginatedTypeMap> =
   ExtractItemType<EndpointToPaginatedTypeMap[T]>;
 
 // define custom error type to support passing Open5e data via an error message
-export interface Open5eError extends NuxtError {
-  data: {
-    key?: string;
-  };
-}
+export type Open5eError = NuxtError<{ key?: string } | string>;
 
 /** Provides the base functions to easily fetch data from the Open5e API. */
 export const useAPI = () => {
@@ -94,7 +90,7 @@ export const useAPI = () => {
   });
 
   return {
-    findMany: async <T extends keyof EndpointToFindManyTypeMap> (
+    findMany: async <T extends keyof EndpointToFindManyTypeMap>(
       endpoint: T,
       sources: string[],
       params: Record<string, unknown> = {},
@@ -111,7 +107,7 @@ export const useAPI = () => {
 
       return res.data.results;
     },
-    findPaginated: async <T extends keyof EndpointToPaginatedTypeMap> (options: {
+    findPaginated: async <T extends keyof EndpointToPaginatedTypeMap>(options: {
       endpoint: T;
       sources: string[];
       pageNo?: number;
@@ -159,7 +155,7 @@ export const useAPI = () => {
   };
 };
 
-export const useFindMany = <T extends keyof EndpointToFindManyTypeMap> (
+export const useFindMany = <T extends keyof EndpointToFindManyTypeMap>(
   endpoint: T,
   params?: Record<string, string | number | boolean>,
 ) => {
@@ -196,9 +192,9 @@ export const useSearch = (queryRef: ComputedRef<string>) => {
     queryFn: () =>
       queryRef.value
         ? findMany(API_ENDPOINTS.search, [], {
-            schema: 'v2',
-            query: queryRef.value,
-          })
+          schema: 'v2',
+          query: queryRef.value,
+        })
         : [],
   });
 };

--- a/app/error.vue
+++ b/app/error.vue
@@ -8,6 +8,15 @@
 
         <p v-if="error?.message">{{ error.message }}</p>
 
+        <p v-if="searchTerm">
+          <button
+            class="font-bold text-red hover:text-blood dark:text-indigo-200 dark:hover:text-red"
+            @click="searchRedirect"
+          >
+            Search for "{{ searchTerm }}"
+          </button>
+        </p>
+
         <button
           class="font-bold text-red hover:text-blood dark:text-indigo-200 dark:hover:text-red"
           @click="handleError"
@@ -85,9 +94,39 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{ error: Open5eError | null }>();
+import {computed} from 'vue';
+const props = defineProps<{ error: Open5eError | null }>();
+
+// Calculate the search term to provide for the user based on the error prop.
+// For 404s this page can be arrived at either by:
+// 1. Getting to an invalid page. In this case error.data will be a json of the form
+// `{path: /first/second/third}`, which we will want to transalte to the search term `third`.
+// Note that paths ending with a `/` don't return 404 and will not show a link.
+// 2. Getting a not found response from the API. In this case error.data will have a `key` property
+// with the value set to the searched entity (e.g. for `/monsters/goblin` it will be `goblin`).
+const searchTerm = computed(() => {
+  if(props.error?.statusCode != 404) {
+    return null;
+  }
+
+  const data = props.error?.data;
+  if(data == null) {
+    return null;
+  }
+
+  if((typeof data === 'string')) {
+    try {
+      return JSON.parse(data)?.path.replace(/.*\/([^/]*)/, '$1');
+    } catch {
+      return null;
+    }
+  }
+
+  return data?.key;
+});
 
 const handleError = () => clearError({ redirect: '/' });
+const searchRedirect = () => clearError({redirect: `/search?text=${searchTerm.value}`});
 </script>
 
 <style>

--- a/app/error.vue
+++ b/app/error.vue
@@ -4,16 +4,16 @@
       <div class="p-4">
         <h1>Critical Failure!</h1>
 
-        <h2>Error {{ error?.statusCode }}</h2>
+        <h2>Error {{ error?.status }}</h2>
 
         <p v-if="error?.message">{{ error.message }}</p>
 
         <p v-if="searchTerm">
           <button
-            class="font-bold text-red hover:text-blood dark:text-indigo-200 dark:hover:text-red"
+            class="text-red hover:text-blood dark:text-indigo-200 dark:hover:text-red"
             @click="searchRedirect"
           >
-            Search for <em>{{ searchTerm }}</em>
+            Search for <strong class="uppercase">"{{ searchTerm }}"</strong> on Open5e
           </button>
         </p>
 
@@ -104,14 +104,12 @@ const props = defineProps<{ error: Open5eError | null }>();
 // 2. Getting a not found response from the API. In this case error.data will have a `key` property
 // with the value set to the searched entity (e.g. for `/monsters/goblin` it will be `goblin`).
 const searchTerm = computed(() => {
-  if(props.error?.statusCode !== 404) return undefined;
+  if(props.error?.status !== 404) return;
 
   const { data } = props.error;
-  if(!data) return undefined;
+  if(!data) return;
 
-  if(typeof data !== 'string') {
-    return data.key;
-  }
+  if(typeof data !== 'string') return data.key;
 
   try {
     return JSON.parse(data)?.path.replace(/.*\/([^/]*)/, '$1');
@@ -121,7 +119,7 @@ const searchTerm = computed(() => {
 });
 
 const handleError = () => clearError({ redirect: '/' });
-const searchRedirect = () => clearError({redirect: `/search?text=${searchTerm.value}`});
+const searchRedirect = () => clearError({ redirect: `/search?text=${searchTerm.value}` });
 </script>
 
 <style>

--- a/app/error.vue
+++ b/app/error.vue
@@ -13,7 +13,7 @@
             class="font-bold text-red hover:text-blood dark:text-indigo-200 dark:hover:text-red"
             @click="searchRedirect"
           >
-            Search for "{{ searchTerm }}"
+            Search for <em>{{ searchTerm }}</em>
           </button>
         </p>
 
@@ -94,7 +94,6 @@
 </template>
 
 <script setup lang="ts">
-import {computed} from 'vue';
 const props = defineProps<{ error: Open5eError | null }>();
 
 // Calculate the search term to provide for the user based on the error prop.
@@ -105,24 +104,20 @@ const props = defineProps<{ error: Open5eError | null }>();
 // 2. Getting a not found response from the API. In this case error.data will have a `key` property
 // with the value set to the searched entity (e.g. for `/monsters/goblin` it will be `goblin`).
 const searchTerm = computed(() => {
-  if(props.error?.statusCode != 404) {
-    return null;
+  if(props.error?.statusCode !== 404) return undefined;
+
+  const { data } = props.error;
+  if(!data) return undefined;
+
+  if(typeof data !== 'string') {
+    return data.key;
   }
 
-  const data = props.error?.data;
-  if(data == null) {
-    return null;
+  try {
+    return JSON.parse(data)?.path.replace(/.*\/([^/]*)/, '$1');
+  } catch {
+    return undefined;
   }
-
-  if((typeof data === 'string')) {
-    try {
-      return JSON.parse(data)?.path.replace(/.*\/([^/]*)/, '$1');
-    } catch {
-      return null;
-    }
-  }
-
-  return data?.key;
 });
 
 const handleError = () => clearError({ redirect: '/' });


### PR DESCRIPTION
Add a button that redirects to `/search?text=<QUERY>` above the "Return to Homepage" button.

The button is wrapped by a paragraph so that it shows on its own line. The logic for calculating the search term is not obvious and is thus explained with a comment on top of the `searchTerm` variable.

The `Open5eError` has been refactored to be more gramatically correct, as it doesn't add the `data` property but just defines what the allowed values for it are.

Closes #863

## How was this tested?

Manually
