### PR TITLE
[PERF] Updated `/monster/[id]` exclude query parameters

### DIFF
--- a/app/pages/monsters/[id].vue
+++ b/app/pages/monsters/[id].vue
@@ -277,10 +277,13 @@ import { formatModifier, snakeToTitleCase, parseChallengeRating } from '@/helper
 
 const rollDice = useDiceRoller();
 
+const EXCLUDE_FIELDS = ['modifiers', 'speed_all', 'saving_throws_all', 'normal_sight_range', 'skill_bonuses_all'];
+
 const params = {
   environments__fields: 'name',
   document__fields: 'name,key,permalink',
-  exclude: 'modifiers'
+  actions__exclude: 'attacks',
+  exclude: EXCLUDE_FIELDS.join(','),
 };
 
 const monsterId = useQueryParameter('id');
@@ -397,7 +400,6 @@ const encounterStore = useEncounterStore();
 
 const addToEncounter = () => {
   if (!monster.value) return;
-  console.log('test');
 
   encounterStore.addMonster(
     monster.value.key,


### PR DESCRIPTION
## Description

This PR updates the `?exclude` query parameters passed to the `useFindOne()` composable able on the `/monsters/[id]` page. The purpose of this update is to remove fields which the page doesn't use from the API response which populates the page, which should improve performances.

N.B. This PR uses a nested `?exclude` query parameter (`?actions__exclude=attacks`)  that at the time of writing is not supported by the API. A PR is open on the API repo is currently open (https://github.com/open5e/open5e-api/pull/919) which adds support for this feature, but until this is merge then the API will ignore the query parameter. Think of it as future-proofing

## Related Issue

Closes #865

## How was this tested?
- CI tests passing
- Spot checked on local Nuxt development server
- `npm run test` and `npm run build` pass without error on local