### PR TITLE
[BUGFIX] Fixed `ToolBar` x-overflow on mobile

### DIFF
--- a/app/components/ToolBar.vue
+++ b/app/components/ToolBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="mt-1 grid gap-3 border-b-4 border-red pb-2 sm:border-none">
+  <ul class="mt-1 grid gap-3 pb-2 sm:border-none">
     <li>
       <ToolButtonSourceSelector />
     </li>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -49,7 +49,7 @@
 
       <!-- Right sidebar -->
       <div
-        class="absolute right-0 z-50 border-white bg-white px-1 transition-transform dark:bg-darkness sm:relative sm:w-auto sm:px-2"
+        class="fixed right-0 z-50 bg-white px-1 transition-transform dark:bg-darkness sm:relative sm:w-auto sm:px-2"
         :class="isToolbarVisible ? 'translate-x-0 ' : 'translate-x-full sm:translate-x-0'"
       >
         <ToolBar


### PR DESCRIPTION
## Description

This PR fixes a visual bug where users were experiencing weird x-overflow issues / layout shift on mobile due to the `ToolBar` being hidden off-screen.

The solution was simply to set the position property of the right-hand aside container from `absolute` to `fixed`
## Related Issue

Closes #894 

## How was this tested?

*Describe how it was tested*

- Spot checked on local Django development server
- All CI tests passes
- Nuxt build process completes without error on local
- Vitest tests all passing on local

