### PR TITLE
[BUGFIX] Fixed Navigation menu overflow on mobile

### DIFF
--- a/app/components/Navigation.vue
+++ b/app/components/Navigation.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="flex w-full grow flex-col overflow-hidden bg-white text-black dark:bg-darkness dark:text-white">
+  <nav class="flex h-full flex-col overflow-y-visible bg-white pb-4 text-black dark:bg-darkness dark:text-white">
     <NuxtLink
       to="/"
       class="bg-red p-5 text-center font-serif text-3xl text-white hover:text-white"
@@ -19,7 +19,7 @@
       >
         <NuxtLink :to="path" class="inline-block w-full" @click="$emit('on-link-clicked')">
           <Icon :name="icon ?? ''" class="mx-4 size-8 text-red"/>
-          <span class=" ">{{ title }}</span>
+          <span>{{ title }}</span>
         </NuxtLink>
       </li>
     </ul>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -2,13 +2,13 @@
   <!-- BACKGROUND (visible behind page content at wide screen widths)       -->
   <!-- bg-radial-gradiant arbitrary classes generate the dotted bg pattern  -->
   <div
-    class="grid min-h-screen justify-center overflow-hidden bg-white bg-[radial-gradient(#ddd_1px,transparent_1px)] [background-size:16px_16px] dark:bg-darkness dark:bg-[radial-gradient(#222_1px,transparent_1px)]"
+    class="grid min-h-screen justify-center bg-white bg-[radial-gradient(#ddd_1px,transparent_1px)] [background-size:16px_16px] dark:bg-darkness dark:bg-[radial-gradient(#222_1px,transparent_1px)]"
   >
     <div class="flex h-full max-w-[1440px] sm:mx-0 sm:w-screen">
       <!-- Left sidebar -->
       <aside
-        class="absolute z-50 flex h-full w-56 flex-col overflow-y-auto text-white transition-transform dark:bg-charcoal sm:relative sm:transition-none"
-        :class="isNavbarVisible ? 'translate-x-2' : '-translate-x-full sm:translate-x-2'"
+        class="absolute z-50 flex w-56 flex-col text-white transition-transform dark:bg-charcoal sm:relative sm:transition-none"
+        :class="isNavbarVisible ? 'translate-x-0' : '-translate-x-full sm:translate-x-0'"
       >
          <Navigation @on-link-clicked="hideSidebars" />
       </aside>
@@ -70,7 +70,7 @@
     <!-- Shade: fades out main content when sidebar expanded on mobile -->
     <div
       v-show="isNavbarVisible || isToolbarVisible"
-      class="fixed left-0 top-0 z-48 size-full bg-basalt/50 sm:hidden"
+      class="fixed left-0 top-0 z-48 size-full bg-basalt/25 sm:hidden"
       @click="hideSidebars"
     />
   </div>


### PR DESCRIPTION
## Description

This PR fixes a bug where the left Navigation menu was not overflowing correctly on small browser windows. 

On the live site setting your browser to a small width and height would cause all navigation links which overflowed to the browser window to be hidden (see issue #906 for a video example).

This  

<img width="626" height="598" alt="Screencastfrom2026-05-1610-44-20-ezgif com-optimize" src="https://github.com/user-attachments/assets/33dbb65b-d5d8-459a-bae6-817b84870696" />

A few minor style tweaks were made while I had my eyes on this issue, LMK if you'd prefer that i broke these changes out into their own PR:
 
- Removed small left-margin from the navigation menu so that it now sits flush with the window edge
- Made the shade which covers the screen when a sub-menu is open more translucent. The contrast was a bit over the top previously 

## Related Issue

Closes #906 

## How was this tested?
- Spot checked on local Nuxt development server
- `npm run build` and `npm run test` run locally (all green, no errors)
- CI tests all passing
