### PR TITLE
fix: correct spelling typos in comments and user-visible text

### DIFF
--- a/app/components/MdViewer.vue
+++ b/app/components/MdViewer.vue
@@ -2,7 +2,7 @@
 /**
  * MdViewer.vue - Renders Markdown content as HTML. Essentially a wrapper for
  * the VueShowdown library with a few extensions for parsing certain custom
- * Markdown tags as custom Nuxt components (via the "extentions" prop)
+ * Markdown tags as custom Nuxt components (via the "extensions" prop)
  *
  * -= PROPS (INPUTS) =-
  * @prop {Boolean} toc - A boolean flag to control whether a Table of Contents

--- a/app/components/ResultsTable.vue
+++ b/app/components/ResultsTable.vue
@@ -16,7 +16,7 @@
  *
  * -= DEPENDENCIES =-
  * This component uses the following sub-components
- * @component ResultsTableRow -> render table rows (refac'd into own cmpnt for readibility)
+ * @component ResultsTableRow -> render table rows (refac'd into own cmpnt for readability)
  * @component ResultsTableHeader -> captures logic for column headers
  */
 </script>

--- a/app/components/ResultsTableHeader.vue
+++ b/app/components/ResultsTableHeader.vue
@@ -59,16 +59,16 @@ const props = defineProps({
   isLeastPriority: { type: Boolean, default: false },
 });
 
-// a list of human-readable subsitutions
-const subsitutions = {
+// a list of human-readable substitutions
+const substitutions = {
   level_int: 'Level',
   dnd_class: 'Classes',
   cr: 'CR',
 };
 
 const format = (input: string) => {
-  if (input in subsitutions) {
-    return subsitutions[input as keyof typeof subsitutions];
+  if (input in substitutions) {
+    return substitutions[input as keyof typeof substitutions];
   }
   // Replace underscores w/ spaces and capitalise initials
   return input

--- a/app/components/ResultsTableRow.vue
+++ b/app/components/ResultsTableRow.vue
@@ -13,7 +13,7 @@
  *      column is hidden on small screen
  *
  * -= DEPENDENCIES =-
- * @component SourceTag – renders doucment source UI
+ * @component SourceTag – renders document source UI
  */
 </script>
 

--- a/app/pages/feats/[id].vue
+++ b/app/pages/feats/[id].vue
@@ -12,7 +12,7 @@
     </h1>
     <section>
       <p v-if="feat.prerequisite">
-        <span class="font-bold after:content-['._']">Prerequistes</span>
+        <span class="font-bold after:content-['._']">Prerequisites</span>
         <span>{{ feat.prerequisite }}</span>
       </p>
 


### PR DESCRIPTION
- extensions (was: extentions) - MdViewer.vue
- readability (was: readibility) - ResultsTable.vue
- substitutions (was: subsitutions) - ResultsTableHeader.vue (variable name + all references, 4 occurrences)
- document (was: doucment) - ResultsTableRow.vue
- prerequisites (was: prerequistes) - pages/feats/[id].vue (user-visible text)

## Description
Corrects spelling typos found across components, helpers, and pages.
All changes are in comments and template strings - no logic was altered,
except the substitutions variable rename which was consistently updated
across all 4 references.

## Related Issue

## How was this tested?
Visually inspected each changed file to confirm correctness.
No functional logic was modified.

