### PR TITLE
[BUGFIX] Filtering spells by class now works

### DIFF
--- a/app/constants/spells.ts
+++ b/app/constants/spells.ts
@@ -26,6 +26,8 @@ export const spellcastingClasses = [
   'Bard',
   'Cleric',
   'Druid',
+  'Ranger',
+  'Paladin',
   'Sorcerer',
   'Warlock',
   'Wizard',

--- a/app/helpers/resultsTableConfig/spells.ts
+++ b/app/helpers/resultsTableConfig/spells.ts
@@ -62,10 +62,10 @@ export const spellFilterSelectFieldsDefinition: ResultTableSelectFieldFilter[] =
   },
   {
     name: 'Class',
-    filterField: 'classes__key__in',
+    filterField: 'classes__name__in',
     options: spellcastingClasses.map((className) => ({
       name: className,
-      value: 'srd_' + className.toLowerCase(),
+      value: className,
     })),
     isLeastPriority: true,
   },
@@ -75,5 +75,5 @@ export const spellFilterDefaults: Readonly<SpellFilterState> = {
   name__contains: '',
   level: undefined,
   school__key: undefined,
-  classes__key__in: undefined,
+  classes__name__in: undefined,
 };

--- a/app/types/filters.ts
+++ b/app/types/filters.ts
@@ -17,7 +17,7 @@ export type SpellFilterState = {
   name__contains?: string;
   level?: string;
   school__key?: string;
-  classes__key__in?: string;
+  classes__name__in?: string;
 };
 
 export type ResultTableSelectFieldFilter = {


### PR DESCRIPTION
## Description

This PR fixes the issue of the `/spells` page results table not filtering spells by `srd-2024` classes. The bug was fixed by updating that matching logic so that instead filtering for matches against the class's name plus the `srd_` prefex (essentially hard-coding the `srd-2014` classes into the filter), it now filters against a class's plain-text name.

While this fixes the issue and is considerably more robust than the previous solution, I foresee issues when we begin adding in base-classes from other sources with slightly different names (ie. the Paladin analogue in Level Up A5e is called the Herald, perhaps there will be a way to alias this?)

This PR additionally adds the missing `Paladin` and `Ranger` classes to the list of filterable spell-casting classes, whose omission was an oversight.

## Related Issue

Closes #902

## How was this tested?
- Spot checked on local Nuxt development server
- `npm run test` and `npm run build` of local (all pass/complete without issue)
- All integration tests passing