### PR TITLE
[BUGFIX] `SearchResult`  component bugs resolved

### DIFF
--- a/app/components/SearchResult.vue
+++ b/app/components/SearchResult.vue
@@ -59,7 +59,7 @@
     </div>
 
     <span
-      v-else-if="result.object_model === 'Item' && result.object.is_magic_item"
+      v-else-if="result.object_model === 'Item' && result.object?.is_magic_item"
       class="text-sm capitalize"
     >
       {{ `${result.object.type}, ${result.object.rarity}` }}

--- a/app/components/SearchResult.vue
+++ b/app/components/SearchResult.vue
@@ -47,7 +47,7 @@
       v-if="result.object_model === 'Creature' && result.object?.cr"
       class="text-sm"
     >
-      <span class="after:content-['_|_']">CR {{ result.object.cr }}</span>
+      <span class="after:content-['_|_']">CR {{ parseChallengeRating(result.object.cr) }}</span>
       <span>{{ `${result.object.type} (${result.object.size})` }}</span>
     </div>
 
@@ -89,7 +89,7 @@
 
 <script setup lang="ts">
 import type { SearchResult } from '@/types';
-import { formatSpellSubtitle } from '@/helpers';
+import { formatSpellSubtitle, parseChallengeRating } from '@/helpers';
 defineProps<{
   query: string;
   result: SearchResult;


### PR DESCRIPTION
## Description

This PR fixes two small bugs in the `SearchResults` component. 
- Monsters returned by the search now correctly parse fractional CRs (via the `parseChallengeRating` helper function)
- TypeErrors where the `is_magic_item` field was being indexed into where it didn't exist have been fixed by adding optional-chaining.

Two single-line fixes and one updated import statement. Simple.

## Related Issue
Closes #913 
Closes #914 

## How was this tested?
- Spot checked on local Nuxt development server
- CI tests passing
- `test` and `build` processes ran without issue or error on local