### PR TITLE
[STYLES] Updated presentation of website header on mobile

### DIFF
--- a/app/components/BreadcrumbLinks.vue
+++ b/app/components/BreadcrumbLinks.vue
@@ -17,16 +17,16 @@
 
 <template>
   <nav
-    class="flex h-min  text-nowrap dark:border-basalt"
+    class="flex h-min text-nowrap border border-smoke bg-white px-4 py-2 dark:border-smoke dark:bg-charcoal"
     aria-label="breadcrumbs"
   >
     <ol class="space-x-1 text-sm font-semibold underline-offset-4 sm:space-x-3">
       <!-- Prepend Home Link to list -->
       <li
-        class="inline-flex items-center align-middle text-gray-700 after:ml-1 after:text-blood after:content-['/'] last:after:content-[''] visited:text-gray-700 hover:text-red-700 dark:text-gray-200 dark:visited:text-gray-200 dark:hover:text-red-400 sm:items-start sm:after:ml-4"
+        class="not:last:sm:after:ml-4 inline-flex items-center align-middle text-gray-700 after:ml-1 after:text-red after:content-['/'] last:after:content-[''] visited:text-gray-700 hover:text-red-700 dark:text-gray-200 dark:visited:text-gray-200 dark:hover:text-red-400 sm:items-start"
       >
         <nuxt-link to="/" class="inline-flex align-middle uppercase  decoration-red">
-          <Icon name="heroicons:home" class="mr-1 mt-[.175rem] align-middle" />
+          <Icon name="heroicons:home" class="mr-1 mt-[.175rem] align-middle text-red" />
           <span>Home</span>
         </nuxt-link>
       </li>

--- a/app/components/Navigation.vue
+++ b/app/components/Navigation.vue
@@ -2,7 +2,7 @@
   <nav class="flex w-full grow flex-col overflow-hidden bg-white text-black dark:bg-darkness dark:text-white">
     <NuxtLink
       to="/"
-      class="bg-red p-5 text-center font-serif text-3xl text-white hover:text-white"
+      class="flex h-16 items-center justify-center bg-red font-serif text-3xl text-white hover:text-white"
       @click="$emit('on-link-clicked')"
     >
       Open5e

--- a/app/components/Navigation.vue
+++ b/app/components/Navigation.vue
@@ -2,7 +2,7 @@
   <nav class="flex w-full grow flex-col overflow-hidden bg-white text-black dark:bg-darkness dark:text-white">
     <NuxtLink
       to="/"
-      class="flex h-16 items-center justify-center bg-red font-serif text-3xl text-white hover:text-white"
+      class="flex h-16 items-center justify-center bg-red py-4 font-serif text-3xl text-white hover:text-white"
       @click="$emit('on-link-clicked')"
     >
       Open5e

--- a/app/components/SidebarToggle.vue
+++ b/app/components/SidebarToggle.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="flex size-10 items-center justify-center rounded-full border-2 bg-gradient-to-t from-blood/50 to-red to-90% transition-all  hover:from-red"
+    class="flex size-10 items-center justify-center rounded-full border-2 bg-red text-white hover:bg-blood"
   >
     <Icon name="majesticons:menu-line" class="size-6" />
   </button>

--- a/app/components/SidebarToggle.vue
+++ b/app/components/SidebarToggle.vue
@@ -1,7 +1,7 @@
 <template>
   <button
-    class="flex size-10 items-center justify-center rounded-full border bg-fog transition-all hover:bg-smoke dark:bg-basalt dark:text-white hover:dark:bg-granite"
+    class="flex size-10 items-center justify-center rounded-full border-2 bg-gradient-to-t from-blood/50 to-red to-90% transition-all  hover:from-red"
   >
-    <Icon name="majesticons:menu-line" />
+    <Icon name="majesticons:menu-line" class="size-6" />
   </button>
 </template>

--- a/app/components/ToolBarToggle.vue
+++ b/app/components/ToolBarToggle.vue
@@ -1,6 +1,6 @@
 <template>
   <button 
-    class="size-10 rounded-full border-2 bg-red transition-all hover:bg-blood"
+    class="size-10 rounded-full border-2 bg-red text-white hover:bg-blood"
     @click="() => $emit('btn-clicked')"
   >
     <Icon name="majesticons:chevron-double-left-line"/>

--- a/app/components/ToolBarToggle.vue
+++ b/app/components/ToolBarToggle.vue
@@ -1,6 +1,6 @@
 <template>
   <button 
-    class="size-10 rounded-full border bg-fog transition-all hover:bg-smoke dark:bg-charcoal dark:text-white dark:hover:bg-granite"
+    class="size-10 rounded-full border-2 bg-red transition-all hover:bg-blood"
     @click="() => $emit('btn-clicked')"
   >
     <Icon name="majesticons:chevron-double-left-line"/>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -21,12 +21,12 @@
         <div class="content-wrapper h-full overflow-y-auto  overflow-x-hidden">
 
           <!-- Site Header: Mobile -->
-          <header class="flex justify-between sm:hidden">
+          <header class="flex h-16 items-center justify-between bg-red sm:hidden">
             <SidebarToggle class="m-2 flex-none" @click="toggleSidebar" />
 
             <NuxtLink
               to="/"
-              class="p-2 pb-0 text-center font-serif text-2xl text-red dark:text-white"
+              class="text-center font-serif text-3xl text-white hover:text-smoke"
             >
               Open5e
             </NuxtLink>
@@ -34,7 +34,7 @@
             <ToolBarToggle class="my-2 mr-4 flex-none" @btn-clicked="toggleToolbar" />
           </header>
           
-          <div class="-mt-3 grid h-min w-full justify-center gap-1 px-2 text-lg sm:m-4 sm:justify-start sm:pl-4">
+          <div class="mt-2 grid h-min w-full justify-center gap-1 px-2 text-lg sm:m-4 sm:justify-start sm:pl-4">
             <BreadcrumbLinks class="grow" />
           </div>
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,7 +17,7 @@ export default defineNuxtConfig({
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
         { key: 'description', name: 'description', content: 'Free and open-source library of 5e rules, monsters, spells, etc. Powered by the Open5e API' },
-        
+        { name: 'theme-color', content: '#E74C3C' },
         // Open Graph metadata
         { property: 'og:title', content: 'Open5e'},
         { property: 'og:site:name', content: 'Open5e' },
@@ -27,7 +27,7 @@ export default defineNuxtConfig({
         { property: 'og:image', content: 'https://open5e.com/img/logo.png'},
         { property: 'og:image:width', content: '200' },
         { property: 'og:image:height', content: '200' },
-
+        
         // Twitter metadata
         { name: 'twitter:card', content: 'summary_large_image' },
         { name: 'twitter:title', content: 'Open5e' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,7 +17,7 @@ export default defineNuxtConfig({
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
         { key: 'description', name: 'description', content: 'Free and open-source library of 5e rules, monsters, spells, etc. Powered by the Open5e API' },
-        { name: 'theme-color', content: '#E74C3C' },
+        { name: 'theme-color', content: '#a82315' },
         // Open Graph metadata
         { property: 'og:title', content: 'Open5e'},
         { property: 'og:site:name', content: 'Open5e' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,7 +17,7 @@ export default defineNuxtConfig({
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
         { key: 'description', name: 'description', content: 'Free and open-source library of 5e rules, monsters, spells, etc. Powered by the Open5e API' },
-        { name: 'theme-color', content: '#a82315' },
+        { name: 'theme-color', content: '#e74c3c' },
         // Open Graph metadata
         { property: 'og:title', content: 'Open5e'},
         { property: 'og:site:name', content: 'Open5e' },


### PR DESCRIPTION
## Description

This PR updates the Open5e website header styles in the following ways:
- Adds a `theme-color`  meta property to the website head, which changes the utility bar on mobile (tested on iOS) to the O5e brand red.
- Changes the background of the header to brand red and all text/icon colors on the header to white.
- Restyles the Breadcrumb navigation

<img width="400" alt="IMG_0483" src="https://github.com/user-attachments/assets/c9b3d3fe-890c-44ce-85fc-5655f92dcb3e" />

<img width="400" alt="IMG_0484" src="https://github.com/user-attachments/assets/5eb6b0ab-8e9b-4505-a822-7701e8afcc25" />

These change do exaggerate the weird  left-page margin issue, which has been fixed in PR #906, which as of writing has not been merged to `staging`.

## Related Issue

Closes #917 

## How was this tested?
- Spot checked on local Nuxt development server
- CI tests passing
- `build` and `test` running without issue on local