### PR TITLE
Improve conditions page and Game systems handling

### DIFF
--- a/app/components/ModalSourceSelector.vue
+++ b/app/components/ModalSourceSelector.vue
@@ -50,11 +50,11 @@
           >
             <option value="">–</option>
             <option
-              v-for="systemOption in allGameSystems"
-              :key="systemOption"
-              :value="systemOption"
+              v-for="system in allGameSystems"
+              :key="system.key"
+              :value="system.key"
             >
-              {{ systemOption }}
+              {{ formatGameSystemTitle(system.name) }}
             </option>
           </select>
         </div>
@@ -147,29 +147,17 @@ import type { Document } from '@/types';
 
 const emit = defineEmits(['close']);
 const closeModal = () => {
-  // reset menu state to current active sources after closing animation finishes
   setTimeout(() => selectedSources.value = [...sources.value], 500);
   emit('close');
 };
 
-const { data: documents } = useDocuments({
-  fields: ['key', 'name', 'publisher', 'gamesystem', 'type'].join(','),
-  publisher__fields: ['name', 'key'].join(','),
-  gamesystem__fields: ['name', 'key'].join(','),
-});
+const {
+  sourceDocuments,
+  miscDocuments,
+  sortedGameSystemsForSourceDocuments,
+} = useCatalog();
 
 const { sources, setSources, gameSystem, setGameSystem } = useSourcesList();
-
-// Seperate SOURCE and MISC documents, only use the former in the modal menu
-// and add the later back in when updating selected sources in local memory
-
-const sourceDocuments = computed(() => (
-  documents?.value?.filter(document => document.type === 'SOURCE') ?? []
-));
-
-const miscDocuments = computed(() => (
-  documents?.value?.filter(document => document.type !== 'SOURCE') ?? []
-));
 
 // Keep selectedSources in sync with global sources state
 const selectedSources: Ref<string[]> = ref([]);
@@ -184,12 +172,11 @@ const noneSelected = computed(() => selectedSources.value.length === 0);
 
 // filter documents by the current game system
 const documentsInSystem = computed<Document[]>(() => {
-  if (!sourceDocuments?.value || sourceDocuments.value.length === 0) return [];
+  if (sourceDocuments.value.length === 0) return [];
   if (!currentSystem.value) return sourceDocuments.value;
-  return sourceDocuments.value.filter((document) => {
-    return document.gamesystem.name === currentSystem.value;
-  });
-
+  return sourceDocuments.value.filter(
+    document => document.gamesystem.key === currentSystem.value,
+  );
 });
 
 // group filtered documents by publisher
@@ -203,14 +190,7 @@ const groupedDocuments = computed<Record<string, Document[]>>(() => {
 
 const currentSystem = ref(gameSystem.value ?? '');
 
-// returns the names of all game systems present in API data
-const allGameSystems = computed(() => {
-  if (!documents.value) return [];
-  return [...new Set(documents.value
-      .map(doc => doc.gamesystem?.name)
-      .filter(Boolean)
-  )];
-});
+const allGameSystems = sortedGameSystemsForSourceDocuments;
 
 // save current form selection to local memory
 function saveSelection() {

--- a/app/components/TabBar.vue
+++ b/app/components/TabBar.vue
@@ -14,8 +14,8 @@
       :tabindex="model === tab.id ? 0 : -1"
       class="cursor-pointer px-4 py-2 text-left transition-colors"
       :class="model === tab.id
-        ? 'border-b-2 border-red text-blood'
-        : 'text-black dark:text-white hover:text-red/50 dark:hover:text-red/50'"
+        ? 'border-b-2 border-red dark:text-red text-blood'
+        : 'text-black dark:text-white hover:text-red/75 dark:hover:text-blood'"
 
       @click="model = tab.id"
       @keydown="onKeydown($event, tab.id)"

--- a/app/components/TabBar.vue
+++ b/app/components/TabBar.vue
@@ -1,0 +1,62 @@
+<template>
+  <div
+    role="tablist"
+    class="flex gap-1 border-b border-granite"
+  >
+    <button
+      v-for="tab in tabs"
+      :id="`tab-${tab.id}`"
+      :key="tab.id"
+      type="button"
+      role="tab"
+      :aria-selected="model === tab.id"
+      :aria-controls="`tabpanel-${tab.id}`"
+      :tabindex="model === tab.id ? 0 : -1"
+      class="cursor-pointer px-4 py-2 text-left transition-colors"
+      :class="model === tab.id
+        ? 'border-b-2 border-red text-blood'
+        : 'text-black dark:text-white hover:text-red/50 dark:hover:text-red/50'"
+
+      @click="model = tab.id"
+      @keydown="onKeydown($event, tab.id)"
+    >
+      <span class="block">{{ tab.label }}</span>
+      <span
+        v-if="tab.subtitle"
+        class="block text-xs text-granite"
+      >
+        {{ tab.subtitle }}
+      </span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { TabBarItem } from '@/types';
+
+const props = defineProps<{
+  tabs: TabBarItem[];
+}>();
+
+const model = defineModel<string>({ required: true });
+
+function onKeydown(event: KeyboardEvent, tabId: string) {
+  const ids = props.tabs.map(tab => tab.id);
+  const currentIndex = ids.indexOf(tabId);
+  if (currentIndex === -1) return;
+
+  let nextIndex = currentIndex;
+
+  if (event.key === 'ArrowRight') {
+    nextIndex = (currentIndex + 1) % ids.length;
+  } else if (event.key === 'ArrowLeft') {
+    nextIndex = (currentIndex - 1 + ids.length) % ids.length;
+  } else {
+    return;
+  }
+
+  event.preventDefault();
+  model.value = ids[nextIndex]!;
+  document.getElementById(`tab-${ids[nextIndex]}`)?.focus();
+}
+</script>

--- a/app/components/ToolButtonSourceSelector.vue
+++ b/app/components/ToolButtonSourceSelector.vue
@@ -23,16 +23,16 @@
 <script setup lang="ts">
 const showModal = ref(false);
 
-const { data: documents } = useDocuments({ fields: 'key', type: 'SOURCE' });
+const { sourceDocuments } = useCatalog();
 const { sources } = useSourcesList();
 
 const selectedSourcesFraction = computed(() => {
-  if (!sources.value || !documents.value) return '';
-  const allSourceDocumentKeys = documents.value.map(document => document.key);
+  if (!sources.value || sourceDocuments.value.length === 0) return '';
+  const allSourceDocumentKeys = sourceDocuments.value.map(document => document.key);
   const numerator = sources.value
     .filter(source => allSourceDocumentKeys.includes(source))
     .length;
-  const denominator = documents.value?.length;
+  const denominator = sourceDocuments.value.length;
   return `${numerator}/${denominator}`;
 });
 

--- a/app/composables/api.ts
+++ b/app/composables/api.ts
@@ -178,32 +178,6 @@ export const useFindMany = <T extends keyof EndpointToFindManyTypeMap> (
   });
 };
 
-export const useDocuments = (
-  params: Record<string, string> = {}
-) => {
-  const { findMany } = useAPI();
-  return useQuery({
-    queryKey: ['findMany', API_ENDPOINTS.documents, params],
-    queryFn: async (): Promise<EndpointToFindManyTypeMap['v2/documents/']> => {
-      const data = await findMany(API_ENDPOINTS.documents, [], params);
-      return data;
-    }
-  });
-};
-
-export const useGameSystems = (
-  params: Record<string, string> = { fields: 'key,name' },
-) => {
-  const { findMany } = useAPI();
-  return useQuery({
-    queryKey: ['findMany', API_ENDPOINTS.gamesystems, params],
-    queryFn: async (): Promise<EndpointToFindManyTypeMap['v2/gamesystems/']> => {
-      const data = await findMany(API_ENDPOINTS.gamesystems, [], params);
-      return data;
-    },
-  });
-};
-
 export const useSearch = (queryRef: ComputedRef<string>) => {
   const { findMany } = useAPI();
   return useQuery({

--- a/app/composables/api.ts
+++ b/app/composables/api.ts
@@ -21,6 +21,7 @@ export const API_ENDPOINTS = {
   rules: 'v2/rulesets/',
   equipment: 'v2/items/',
   licenses: 'v2/licenses/',
+  gamesystems: 'v2/gamesystems/',
 } as const;
 
 export interface EndpointToFindOneTypeMap {
@@ -53,6 +54,7 @@ export interface EndpointToFindManyTypeMap {
   'v2/spells/': Schemas['Spell'][];
   'v2/rulesets/': Schemas['RuleSet'][];
   'v2/licenses/': Schemas['License'][];
+  'v2/gamesystems/': Schemas['GameSystem'][];
 }
 
 export interface EndpointToPaginatedTypeMap {
@@ -74,7 +76,7 @@ export interface EndpointToPaginatedTypeMap {
 export type ExtractItemType<T> = T extends { results: (infer U)[] } ? U : never;
 
 // convenience type to get item type from endpoint key
-export type ExtractPaginatedItemType<T extends keyof EndpointToPaginatedTypeMap> = 
+export type ExtractPaginatedItemType<T extends keyof EndpointToPaginatedTypeMap> =
   ExtractItemType<EndpointToPaginatedTypeMap[T]>;
 
 // define custom error type to support passing Open5e data via an error message
@@ -186,6 +188,19 @@ export const useDocuments = (
       const data = await findMany(API_ENDPOINTS.documents, [], params);
       return data;
     }
+  });
+};
+
+export const useGameSystems = (
+  params: Record<string, string> = { fields: 'key,name' },
+) => {
+  const { findMany } = useAPI();
+  return useQuery({
+    queryKey: ['findMany', API_ENDPOINTS.gamesystems, params],
+    queryFn: async (): Promise<EndpointToFindManyTypeMap['v2/gamesystems/']> => {
+      const data = await findMany(API_ENDPOINTS.gamesystems, [], params);
+      return data;
+    },
   });
 };
 

--- a/app/composables/useCatalog.ts
+++ b/app/composables/useCatalog.ts
@@ -1,0 +1,81 @@
+import { useQuery } from '@tanstack/vue-query';
+import { computed } from 'vue';
+import { API_ENDPOINTS, useAPI } from '@/composables/api';
+import { sortGameSystemKeys as sortGameSystemKeysHelper, sortGameSystems } from '@/helpers';
+import type { Document } from '@/types';
+import type { components } from '@/types/open5e-api';
+
+type GameSystem = components['schemas']['GameSystem'];
+
+const CATALOG_DOCUMENT_PARAMS = {
+  fields: ['key', 'name', 'type', 'desc', 'publisher', 'gamesystem', 'licenses'].join(','),
+  publisher__fields: ['name', 'key'].join(','),
+  gamesystem__fields: ['name', 'key'].join(','),
+};
+
+export function useCatalog() {
+  const { findMany } = useAPI();
+
+  const documentsQuery = useQuery({
+    queryKey: ['catalog', 'documents'],
+    queryFn: async (): Promise<Document[]> =>
+      findMany(API_ENDPOINTS.documents, [], CATALOG_DOCUMENT_PARAMS),
+  });
+
+  const gameSystemsQuery = useQuery({
+    queryKey: ['catalog', 'gameSystems'],
+    queryFn: async (): Promise<GameSystem[]> => {
+      const data = await findMany(
+        API_ENDPOINTS.gamesystems,
+        [],
+        { fields: 'key,name' },
+      );
+      return sortGameSystems(data);
+    },
+  });
+
+  const documents = computed(() => documentsQuery.data.value ?? []);
+  const gameSystems = computed(() => gameSystemsQuery.data.value ?? []);
+
+  const sourceDocuments = computed(() =>
+    documents.value.filter(document => document.type === 'SOURCE'),
+  );
+
+  const miscDocuments = computed(() =>
+    documents.value.filter(document => document.type !== 'SOURCE'),
+  );
+
+  const sortedGameSystemsForSourceDocuments = computed(() => {
+    const presentKeys = new Set(
+      sourceDocuments.value
+        .map(document => document.gamesystem?.key)
+        .filter(Boolean),
+    );
+    return gameSystems.value.filter(system => presentKeys.has(system.key));
+  });
+
+  const documentName = (key: string) =>
+    documents.value.find(document => document.key === key)?.name ?? key;
+
+  const gameSystemName = (key: string) =>
+    gameSystems.value.find(system => system.key === key)?.name ?? key;
+
+  const sortGameSystemKeys = (keys: string[]) =>
+    sortGameSystemKeysHelper(
+      keys,
+      Object.fromEntries(gameSystems.value.map(system => [system.key, system.name])),
+    );
+
+  return {
+    documents,
+    sourceDocuments,
+    miscDocuments,
+    sortedGameSystemsForSourceDocuments,
+    documentName,
+    gameSystemName,
+    sortGameSystemKeys,
+    isLoading: computed(() =>
+      documentsQuery.isLoading.value || gameSystemsQuery.isLoading.value,
+    ),
+  };
+}

--- a/app/composables/useCatalog.ts
+++ b/app/composables/useCatalog.ts
@@ -2,10 +2,7 @@ import { useQuery } from '@tanstack/vue-query';
 import { computed } from 'vue';
 import { API_ENDPOINTS, useAPI } from '@/composables/api';
 import { sortGameSystemKeys as sortGameSystemKeysHelper, sortGameSystems } from '@/helpers';
-import type { Document } from '@/types';
-import type { components } from '@/types/open5e-api';
-
-type GameSystem = components['schemas']['GameSystem'];
+import type { Document, GameSystem } from '@/types';
 
 const CATALOG_DOCUMENT_PARAMS = {
   fields: ['key', 'name', 'type', 'desc', 'publisher', 'gamesystem', 'licenses'].join(','),

--- a/app/composables/useCatalog.ts
+++ b/app/composables/useCatalog.ts
@@ -1,3 +1,6 @@
+// useCatalog manages information about the source Documents and GameSystems 
+// present in the the Open5e dataset, in addition their inter-relations.
+
 import { useQuery } from '@tanstack/vue-query';
 import { computed } from 'vue';
 import { API_ENDPOINTS, useAPI } from '@/composables/api';

--- a/app/composables/useSourcesList.ts
+++ b/app/composables/useSourcesList.ts
@@ -3,7 +3,7 @@ import { computed, ref } from 'vue';
 const defaultSources = ['srd-2014', 'srd-2024', 'core', 'elderberry-inn-icons'];
 
 function loadSourcesFromLocalStorage(): string[] {
-  if (!import.meta.client) return []; // skip on server (no lcoal storage)
+  if (!import.meta.client) return [];
   const saved_sources = localStorage.getItem('sources');
   return saved_sources ? JSON.parse(saved_sources) : defaultSources;
 }
@@ -14,22 +14,23 @@ function writeSourcesToLocalStorage(sourcesList: string[]) {
 
 const _sources = ref<string[]>(loadSourcesFromLocalStorage());
 
-const loadGameSystemFromStorage = () => {
+function loadGameSystemFromStorage(): string {
   if (!import.meta.client) return '';
-  return localStorage.getItem('gamesystem');
+  return localStorage.getItem('gamesystem') ?? '';
+}
+
+const writeGameSystemToStorage = (input: string) => {
+  if (input) localStorage.setItem('gamesystem', input);
+  else localStorage.removeItem('gamesystem');
 };
 
-const writeGameSystenToStorage = (input: string) =>
-  localStorage.setItem('gamesystem', input);
-
-const gameSystem = ref<string | null>(loadGameSystemFromStorage());
+const gameSystem = ref<string>(loadGameSystemFromStorage());
 
 const setGameSystem = (input: string) => {
   gameSystem.value = input;
-  writeGameSystenToStorage(input);
+  writeGameSystemToStorage(input);
 };
 
-// Overwrite all sources, update local storage
 export const setSources = (sources: string[]) => {
   const dedupedSources = [...new Set(sources)];
   _sources.value = dedupedSources;
@@ -38,12 +39,10 @@ export const setSources = (sources: string[]) => {
 
 export const read_only_source_list = computed(() => _sources.value);
 
-/** Access the global list of sources documents. These are used to limit which documents are used in API queries. */
+/** Access the global list of sources documents and the user's active game system key. */
 export const useSourcesList = () => ({
-  /** List of source tags */
   sources: read_only_source_list,
   gameSystem,
   setGameSystem,
   setSources,
 });
-

--- a/app/helpers/index.ts
+++ b/app/helpers/index.ts
@@ -2,6 +2,7 @@ export { formatAbilityName } from './formatAbilityName';
 export { formatModifier } from './formatModifier';
 export { formatSpellSubtitle } from './formatSpellSubtitle';
 export { sortDocumentsByPublisher } from './sortDocumentsByPublisher';
+export { compareGameSystems, sortGameSystemKeys, sortGameSystems } from './sortGameSystems';
 export { parseChallengeRating } from './parseChallengeRating';
 export { snakeToTitleCase } from './snakeToTitleCase';
 export { titleCaseToKebabCase } from './titleCaseToKebabCase';

--- a/app/helpers/sortGameSystems.ts
+++ b/app/helpers/sortGameSystems.ts
@@ -1,0 +1,38 @@
+export interface GameSystemSortable {
+  key: string;
+  name: string;
+}
+
+const GAME_SYSTEM_PRIORITY = ['5e-2024', '5e-2014'] as const;
+
+function gameSystemPriority(key: string): number {
+  const index = GAME_SYSTEM_PRIORITY.indexOf(
+    key as (typeof GAME_SYSTEM_PRIORITY)[number],
+  );
+  return index === -1 ? GAME_SYSTEM_PRIORITY.length : index;
+}
+
+export function compareGameSystems(
+  a: GameSystemSortable,
+  b: GameSystemSortable,
+): number {
+  const priorityDiff = gameSystemPriority(a.key) - gameSystemPriority(b.key);
+  if (priorityDiff !== 0) return priorityDiff;
+  return a.name.localeCompare(b.name);
+}
+
+export function sortGameSystems<T extends GameSystemSortable>(systems: T[]): T[] {
+  return [...systems].sort(compareGameSystems);
+}
+
+export function sortGameSystemKeys(
+  keys: string[],
+  nameByKey: Record<string, string> = {},
+): string[] {
+  return [...keys].sort((a, b) =>
+    compareGameSystems(
+      { key: a, name: nameByKey[a] ?? a },
+      { key: b, name: nameByKey[b] ?? b },
+    ),
+  );
+}

--- a/app/pages/conditions/[id].vue
+++ b/app/pages/conditions/[id].vue
@@ -3,7 +3,7 @@
     v-if="condition"
     class="docs-container container"
   >
-    <h1 class="p-b-4">
+    <h1 class="m-b-4">
       <span>{{ condition.name }}</span>
       <source-tag
         v-if="sourceKey"

--- a/app/pages/conditions/[id].vue
+++ b/app/pages/conditions/[id].vue
@@ -3,7 +3,7 @@
     v-if="condition"
     class="docs-container container"
   >
-    <h1>
+    <h1 class="p-b-4">
       <span>{{ condition.name }}</span>
       <source-tag
         v-if="sourceKey"
@@ -12,48 +12,119 @@
       />
     </h1>
 
-    <!-- Display condition descriptions as a list if API rtns more than one -->
-    <div v-if="condition.descriptions.length > 1">
-      <p class="my-4 italic">
-        <span>The </span>
-        <span class="font-bold">{{ condition.name }}</span>
-        <span> condition has multiple definitions in different rulebooks.</span>
-      </p>
-      <dl class="grid gap-6">
-        <div v-for="description in condition.descriptions" :key="description.document">
-          <dt class="text-xl font-bold text-granite">
-            {{ description.gamesystem }}
-          </dt>
-          <dd class="mt-0">
-            <MdViewer :text="description.desc"/>
-          </dd>
-        </div>
-      </dl>
-    </div>
+    <p v-if="visibleDescriptions.length === 0" class="my-4 italic text-granite">
+      No definitions for this condition match your current source selection.
+    </p>
 
-    <!-- Display conditions with a single description as they are -->
-    <v-else>
-      <MdViewer :text="condition.descriptions[0].desc" />
-    </v-else>
+    <MdViewer
+      v-else-if="visibleDescriptions.length === 1"
+      :text="visibleDescriptions[0].desc"
+    />
+
+    <template v-else-if="tabItems.length >= 2">
+      <TabBar v-model="activeTab" :tabs="tabItems" class="my-4" />
+
+      <div
+        :id="`tabpanel-${activeTab}`"
+        role="tabpanel"
+        :aria-labelledby="`tab-${activeTab}`"
+      >
+        <template v-if="activeDescriptions.length === 1">
+          <MdViewer :text="activeDescriptions[0].desc" />
+        </template>
+
+        <div v-else class="grid gap-4">
+          <div
+            v-for="description in activeDescriptions"
+            :key="description.document"
+            class="rounded border border-fog p-4 dark:border-charcoal"
+          >
+            <SourceTag
+              :text="description.document"
+              :title="documentName(description.document)"
+            />
+            <MdViewer :text="description.desc" />
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <div v-else class="grid gap-4">
+      <div
+        v-for="description in visibleDescriptions"
+        :key="description.document"
+        class="rounded border border-fog p-4 dark:border-charcoal"
+      >
+        <SourceTag
+          :text="description.document"
+          :title="documentName(description.document)"
+        />
+        <MdViewer :text="description.desc" />
+      </div>
+    </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import type { Condition } from '@/types';
+import type { Condition, TabBarItem } from '@/types';
+
+type ConditionDescription = Condition['descriptions'][number];
 
 const conditionId = useQueryParameter('id');
 const { data: condition } = useFindOne(API_ENDPOINTS.conditions, conditionId,
-  { 
-    params: { 
+  {
+    params: {
       fields: ['name', 'descriptions', 'document'].join(','),
-      document__fields: ['key', 'display_name'].join(',')
-    } 
+      document__fields: ['key', 'display_name'].join(','),
+    },
   },
 );
 
 useSeoEntry(condition as Ref<Condition>);
 
-// generate source key from page URL - for use with source-tab cmpnt
+const { sources } = useSourcesList();
+const { documentName, gameSystemName, sortGameSystemKeys } = useCatalog();
+
+const visibleDescriptions = computed(() =>
+  condition.value?.descriptions.filter(
+    description => sources.value.includes(description.document),
+  ) ?? [],
+);
+
+const descriptionsByGameSystem = computed(() => {
+  const groups = new Map<string, ConditionDescription[]>();
+
+  for (const description of visibleDescriptions.value) {
+    const existing = groups.get(description.gamesystem) ?? [];
+    groups.set(description.gamesystem, [...existing, description]);
+  }
+
+  return groups;
+});
+
+const tabItems = computed<TabBarItem[]>(() =>
+  sortGameSystemKeys([...descriptionsByGameSystem.value.keys()]).map(key => ({
+    id: key,
+    label: gameSystemName(key),
+  })),
+);
+
+const activeTab = ref('');
+
+watch(tabItems, (tabs) => {
+  if (tabs.length === 0) {
+    activeTab.value = '';
+    return;
+  }
+  if (!tabs.some(tab => tab.id === activeTab.value)) {
+    activeTab.value = tabs[0]!.id;
+  }
+}, { immediate: true });
+
+const activeDescriptions = computed(() =>
+  descriptionsByGameSystem.value.get(activeTab.value) ?? [],
+);
+
 const sourceKey = computed(() => {
   if (!condition?.value?.document) return;
   return condition.value.document.key;

--- a/app/pages/sources/index.vue
+++ b/app/pages/sources/index.vue
@@ -1,12 +1,12 @@
 <template>
   <section class="docs-container container">
     <div>
-      <h1>Sources</h1>
+      <h1 p-b-2>Sources</h1>
 
       <!-- Outer list is a list of Publishers -->
       <ul>
-        <li 
-          v-for="(docs, publisher) in sortDocumentsByPublisher(documents as Document[])"
+        <li
+          v-for="(docs, publisher) in sortDocumentsByPublisher(documents)"
           :key="publisher"
         >
           <!-- Inner list is a list of Sources per Publisher -->
@@ -14,7 +14,7 @@
           <dl class="flex flex-col">
 
             <!-- Card for each Source -->
-            <div 
+            <div
               v-for="doc in docs"
               :key="doc.name"
               class="my-2 border bg-fog p-2 dark:bg-basalt"
@@ -29,7 +29,7 @@
                 <p class="mt-0">{{ doc.desc?.split(" ").slice(0,50).join(" ") }}</p>
                 <p v-if="doc.licenses.length > 0" class="mt-0 text-sm text-gray-500">
                   {{`
-                    Published under the 
+                    Published under the
                     ${doc.licenses.map((l) => l.key).join(' / ').toUpperCase()}
                     ${" " + (doc.licenses.length > 1) ? "licenses" : "license"}`}}
                 </p>
@@ -43,8 +43,8 @@
 </template>
 
 <script setup lang="ts">
-import type { Document } from '@/types';
 import { sortDocumentsByPublisher } from '@/helpers';
-const { data: documents } = useDocuments();
+
+const { documents } = useCatalog();
 useSeoIndex({ title: 'Documents' });
 </script>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -14,6 +14,7 @@ export type CreatureTypeSummary = components['schemas']['CreatureTypeSummary'];
 export type Document = components['schemas']['Document'];
 export type DocumentSummary = components['schemas']['DocumentSummary'];
 export type Feat = components['schemas']['Feat'];
+export type GameSystem = components['schemas']['GameSystem'];
 export type License = components['schemas']['License'];
 export type Rule = components['schemas']['Rule'];
 export type RuleSet = components['schemas']['RuleSet'];

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -57,6 +57,12 @@ export type SearchObjectPayload = {
 }
 
 // type interface for the `cols` prop
+export interface TabBarItem {
+  id: string;
+  label: string;
+  subtitle?: string;
+}
+
 export interface TableColumn<T extends Open5eData> {
   displayName: string;
   value: (data: T) => string | number | boolean;

--- a/tests/unit/components/TabBar.test.tsx
+++ b/tests/unit/components/TabBar.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import TabBar from '~/components/TabBar.vue';
+
+const tabs = [
+  { id: '5e-2014', label: '5th Edition 2014', subtitle: '5e-2014' },
+  { id: '5e-2024', label: '5th Edition 2024', subtitle: '5e-2024' },
+  { id: 'a5e', label: 'Advanced 5th Edition', subtitle: 'a5e' },
+];
+
+function mountTabBar(activeId = '5e-2014') {
+  const activeTab = ref(activeId);
+  const wrapper = mount(TabBar, {
+    props: {
+      tabs,
+      modelValue: activeTab.value,
+      'onUpdate:modelValue': (value: string) => {
+        activeTab.value = value;
+      },
+    },
+  });
+  return { wrapper, activeTab };
+}
+
+describe('TabBar', () => {
+  it('renders tab labels and subtitles', () => {
+    const { wrapper } = mountTabBar();
+    expect(wrapper.text()).toContain('5th Edition 2014');
+    expect(wrapper.text()).toContain('5e-2014');
+    expect(wrapper.text()).toContain('Advanced 5th Edition');
+  });
+
+  it('marks the active tab with aria-selected', () => {
+    const { wrapper } = mountTabBar('5e-2024');
+    const tabButtons = wrapper.findAll('[role="tab"]');
+    expect(tabButtons[1]?.attributes('aria-selected')).toBe('true');
+    expect(tabButtons[0]?.attributes('aria-selected')).toBe('false');
+  });
+
+  it('updates model when a tab is clicked', async () => {
+    const { wrapper, activeTab } = mountTabBar();
+    await wrapper.findAll('[role="tab"]')[2]?.trigger('click');
+    expect(activeTab.value).toBe('a5e');
+  });
+
+  it('moves selection with arrow keys', async () => {
+    const { wrapper, activeTab } = mountTabBar('5e-2014');
+    await wrapper.find('#tab-5e-2014').trigger('keydown', { key: 'ArrowRight' });
+    expect(activeTab.value).toBe('5e-2024');
+    await wrapper.find('#tab-5e-2024').trigger('keydown', { key: 'ArrowLeft' });
+    expect(activeTab.value).toBe('5e-2014');
+  });
+});

--- a/tests/unit/helpers/sortGameSystems.test.ts
+++ b/tests/unit/helpers/sortGameSystems.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  compareGameSystems,
+  sortGameSystemKeys,
+  sortGameSystems,
+} from '@/helpers/sortGameSystems';
+
+const systems = [
+  { key: 'a5e', name: 'Advanced 5th Edition' },
+  { key: '5e-2014', name: '5th Edition 2014' },
+  { key: '5e-2024', name: '5th Edition 2024' },
+];
+
+describe('sortGameSystems', () => {
+  it('orders 2024 and 2014 SRD before others alphabetically by name', () => {
+    expect(sortGameSystems(systems).map(system => system.key)).toEqual([
+      '5e-2024',
+      '5e-2014',
+      'a5e',
+    ]);
+  });
+
+  it('sorts remaining systems alphabetically by name', () => {
+    const unsorted = [
+      { key: 'zebra', name: 'Zebra System' },
+      { key: '5e-2024', name: '5th Edition 2024' },
+      { key: 'alpha', name: 'Alpha System' },
+    ];
+    expect(sortGameSystems(unsorted).map(system => system.key)).toEqual([
+      '5e-2024',
+      'alpha',
+      'zebra',
+    ]);
+  });
+});
+
+describe('sortGameSystemKeys', () => {
+  it('sorts keys using name lookup', () => {
+    const nameByKey = Object.fromEntries(systems.map(system => [system.key, system.name]));
+    expect(sortGameSystemKeys(['a5e', '5e-2014', '5e-2024'], nameByKey)).toEqual([
+      '5e-2024',
+      '5e-2014',
+      'a5e',
+    ]);
+  });
+});
+
+describe('compareGameSystems', () => {
+  it('returns zero for equivalent entries', () => {
+    expect(compareGameSystems(
+      { key: '5e-2014', name: '5th Edition 2014' },
+      { key: '5e-2014', name: '5th Edition 2014' },
+    )).toBe(0);
+  });
+});

--- a/tests/unit/pages/condition.test.tsx
+++ b/tests/unit/pages/condition.test.tsx
@@ -1,46 +1,101 @@
-import { test, expect } from 'vitest';
+import { describe, test, expect, beforeAll } from 'vitest';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
+import { ref } from 'vue';
 import ConditionPage from '~/pages/conditions/[id].vue';
 
-const { data: condition } = useFindOne(API_ENDPOINTS.conditions, 'blinded');
+const mockCondition = {
+  name: 'Blinded',
+  descriptions: [
+    {
+      desc: '* A blinded creature can\'t see and it automatically fails ability checks that require sight.',
+      document: 'a5e-ag',
+      gamesystem: 'a5e',
+    },
+    {
+      desc: '* A blinded creature can\'t see and automatically fails any ability check that requires sight.',
+      document: 'srd-2014',
+      gamesystem: '5e-2014',
+    },
+    {
+      desc: 'While you have the Blinded condition, you experience the following effects.',
+      document: 'srd-2024',
+      gamesystem: '5e-2024',
+    },
+  ],
+  document: {
+    key: 'srd-2014',
+    name: 'Systems Reference Document',
+  },
+};
 
-const page = await mountSuspended(ConditionPage);
-
-test('/conditions/[id] page can mount', async () => {
-  expect(page);
-});
-
-test('/conditions/[id] page renders title', async () => {
-  const title = page.find('h1');
-  expect(title.exists()).toBe(true);
-  expect(title.text()).toEqual(unref(condition)?.name);
-});
+const sources = ref(['a5e-ag', 'srd-2014', 'srd-2024']);
 
 mockNuxtImport('useFindOne', () => {
+  return () => ({ data: ref(mockCondition) });
+});
+
+mockNuxtImport('useSourcesList', () => {
+  return () => ({ sources });
+});
+
+mockNuxtImport('useCatalog', () => {
   return () => ({
-    data: {
-      name: 'Blinded',
-      "descriptions": [
-        {
-            "desc": "* A blinded creature can’t see and it automatically fails ability checks that require sight.\n\n* Attack rolls against a blinded creature are made with advantage, and the creature’s attack rolls are made with disadvantage.",
-            "document": "a5e-ag",
-            "gamesystem": "a5e"
-        },
-        {
-            "desc": "* A blinded creature can't see and automatically fails any ability check that requires sight.\r\n* Attack rolls against the creature have advantage, and the creature’s attack rolls have disadvantage.",
-            "document": "srd-2014",
-            "gamesystem": "5e-2014"
-        },
-        {
-            "desc": "While you have the Blinded condition, you experience the following effects.\n * Can’t See. You can’t see and automatically fail any ability check that requires sight.\n * Attacks Affected. Attack rolls against you have Advantage, and your attack rolls have Disadvantage.",
-            "document": "srd-2024",
-            "gamesystem": "5e-2024"
-        }
-      ],
-      document: {
-        name: 'Systems Reference Document',
-        url: 'v2/documents/srd/',
-      },
+    documentName: (key: string) => ({
+      'a5e-ag': 'Adventurers Guide',
+      'srd-2014': 'Systems Reference Document',
+      'srd-2024': 'Systems Reference Document 2024',
+    })[key] ?? key,
+    gameSystemName: (key: string) => ({
+      'a5e': 'Advanced 5th Edition',
+      '5e-2014': '5th Edition 2014',
+      '5e-2024': '5th Edition 2024',
+    })[key] ?? key,
+    sortGameSystemKeys: (keys: string[]) => {
+      const order = ['5e-2024', '5e-2014', 'a5e'];
+      return [...keys].sort(
+        (a, b) => order.indexOf(a) - order.indexOf(b),
+      );
     },
+  });
+});
+
+describe('/conditions/[id]', () => {
+  let page: Awaited<ReturnType<typeof mountSuspended>>;
+
+  beforeAll(async () => {
+    page = await mountSuspended(ConditionPage);
+  });
+
+  test('page can mount', () => {
+    expect(page).toBeTruthy();
+  });
+
+  test('page renders title', () => {
+    const title = page.find('h1');
+    expect(title.exists()).toBe(true);
+    expect(title.text()).toContain('Blinded');
+  });
+
+  test('does not show the multiple-definitions explainer', () => {
+    expect(page.text()).not.toContain('has multiple definitions in different rulebooks');
+  });
+
+  test('shows human-readable game system names in tabs', () => {
+    expect(page.text()).toContain('5th Edition 2014');
+    expect(page.text()).toContain('Advanced 5th Edition');
+    expect(page.find('[role="tablist"]').exists()).toBe(true);
+  });
+
+  test('orders tabs with 2024 SRD first, then 2014 SRD, then others', () => {
+    const tabs = page.findAll('[role="tab"]');
+    expect(tabs[0]?.text()).toContain('5th Edition 2024');
+    expect(tabs[1]?.text()).toContain('5th Edition 2014');
+    expect(tabs[2]?.text()).toContain('Advanced 5th Edition');
+  });
+
+  test('hides tabs when only one source is selected', async () => {
+    sources.value = ['srd-2014'];
+    await page.vm.$nextTick();
+    expect(page.find('[role="tablist"]').exists()).toBe(false);
   });
 });


### PR DESCRIPTION
## Description

**Created "catalog" which maps documents and gamesystems:**

* Added a new composable `useCatalog`
* Fetch game systems from API and map to documents, storing this in the local storage
* Updated `ModalSourceSelector.vue`, `ToolButtonSourceSelector.vue`, and `sources/index.vue` to use the new catalog for system names

**Game System Sorting and Selection Improvements:**

* Added helpers to consistently sort game systems with priority for 5e-2024 and 5e-2014, and refactored relevant UI components to use these.

**UI/UX Enhancements for Conditions:**

* Overhauled the conditions detail page to group and display condition descriptions by game system using the `TabBar` component, showing only definitions matching the user's selected sources and game system. 

## Related Issue

Closes #877 

## How was this tested?

Tested in local

