### PR TITLE
Styling adjustments to inputs, buttons, and pagination

### DIFF
--- a/app/components/BreadcrumbLinks.vue
+++ b/app/components/BreadcrumbLinks.vue
@@ -17,7 +17,7 @@
 
 <template>
   <nav
-    class="flex h-min text-nowrap border border-smoke bg-white px-4 py-2 dark:border-smoke dark:bg-charcoal"
+    class="flex h-min text-nowrap"
     aria-label="breadcrumbs"
   >
     <ol class="space-x-1 text-sm font-semibold underline-offset-4 sm:space-x-3">

--- a/app/components/ModalReportIssue.vue
+++ b/app/components/ModalReportIssue.vue
@@ -87,7 +87,7 @@ const submitIssue = async () => {
             <select
               v-model="formData.type"
               name="type"
-              class="w-full border bg-transparent p-2 dark:bg-basalt"
+              class="form-select transparent w-full border p-2 dark:bg-basalt"
             >
               <option value="page">
                 A page is broken or doesn't load properly

--- a/app/components/ModalSourceSelector.vue
+++ b/app/components/ModalSourceSelector.vue
@@ -25,7 +25,7 @@
       <!-- MODAL MENU TITLE BAR -->
       <div class="flex w-full items-center justify-between">
 
-        <input 
+        <input
           id="select-deselect-all-checkbox"
           type="checkbox"
           :checked="allSelected"
@@ -38,14 +38,14 @@
         <h2 class="my-0 grow text-3xl">Sources Selector</h2>
 
         <!--  GAME SYSTEM SELECTOR -->
-        <div class="mb-2 grid">
-          <label class="text-right font-serif text-sm" for="system">
+        <div class="mb-2 grid border-b-[3px] border-red pb-[6px]">
+          <label class="text-right font-serif text-xs" for="system">
             System
           </label>
           <select
             id="system"
             v-model="currentSystem"
-            class="cursor-pointer appearance-none border-b-2 border-red bg-transparent text-right text-sm"
+            class="form-select cursor-pointer appearance-none text-right text-sm"
             @change="selectAllInSystem"
           >
             <option value="">–</option>
@@ -89,7 +89,7 @@
           </span>
 
           <ul v-if="!allPublisherSourcesInactive(publisher)">
-            <li 
+            <li
               v-for="document in documentsPerPublisher"
               :key="document.key"
               class="group flex w-full items-center"
@@ -110,12 +110,12 @@
               </label>
 
               <SourceTag :title="document.name" :text="document.key" />
-              
+
               <span
                 v-if="document.gamesystem"
                 class="ml-auto h-min rounded-xl bg-fog px-2 text-xs dark:bg-slate-800"
               >
-                {{ formatGameSystemTitle(document.gamesystem.name) }}
+                {{ gameSystemName(document.gamesystem.key) }}
               </span>
             </li>
           </ul>
@@ -271,13 +271,4 @@ function selectAllInSystem() {
 }
 
 const deselectAll = () => (selectedSources.value = []);
-
-function formatGameSystemTitle(input: string) {
-  const systemNameMap: Record<string, string> = {
-    '5th Edition 2014': '5e 2014',
-    '5th Edition 2024': '5e 2024',
-    'Advanced 5th Edition': 'Level Up A5e',
-  };
-  return systemNameMap[input] ?? input;
-}
 </script>

--- a/app/components/ModalSourceSelector.vue
+++ b/app/components/ModalSourceSelector.vue
@@ -115,7 +115,7 @@
                 v-if="document.gamesystem"
                 class="ml-auto h-min rounded-xl bg-fog px-2 text-xs dark:bg-slate-800"
               >
-                {{ gameSystemName(document.gamesystem.key) }}
+                {{ formatGameSystemTitle(document.gamesystem.name) }}
               </span>
             </li>
           </ul>
@@ -271,4 +271,13 @@ function selectAllInSystem() {
 }
 
 const deselectAll = () => (selectedSources.value = []);
+
+function formatGameSystemTitle(input: string) {
+  const systemNameMap: Record<string, string> = {
+    '5th Edition 2014': '5e 2014',
+    '5th Edition 2024': '5e 2024',
+    'Advanced 5th Edition': 'Level Up A5e',
+  };
+  return systemNameMap[input] ?? input;
+}
 </script>

--- a/app/components/ModalSourceSelector.vue
+++ b/app/components/ModalSourceSelector.vue
@@ -50,11 +50,11 @@
           >
             <option value="">–</option>
             <option
-              v-for="systemOption in allGameSystems"
-              :key="systemOption"
-              :value="systemOption"
+              v-for="systemName in allGameSystems"
+              :key="systemName"
+              :value="systemName"
             >
-              {{ systemOption }}
+              {{ formatGameSystemTitle(systemName) }}
             </option>
           </select>
         </div>
@@ -186,9 +186,9 @@ const noneSelected = computed(() => selectedSources.value.length === 0);
 const documentsInSystem = computed<Document[]>(() => {
   if (!sourceDocuments?.value || sourceDocuments.value.length === 0) return [];
   if (!currentSystem.value) return sourceDocuments.value;
-  return sourceDocuments.value.filter((document) => {
-    return document.gamesystem.name === currentSystem.value;
-  });
+  return sourceDocuments.value.filter(
+    document => document.gamesystem?.name === currentSystem.value,
+  );
 
 });
 
@@ -203,14 +203,13 @@ const groupedDocuments = computed<Record<string, Document[]>>(() => {
 
 const currentSystem = ref(gameSystem.value ?? '');
 
-// returns the names of all game systems present in API data
-const allGameSystems = computed(() => {
-  if (!documents.value) return [];
-  return [...new Set(documents.value
-      .map(doc => doc.gamesystem?.name)
-      .filter(Boolean)
-  )];
-});
+const allGameSystems = computed(() => [
+  ...new Set(
+    sourceDocuments.value
+      .map(document => document.gamesystem?.name)
+      .filter(Boolean),
+  ),
+]);
 
 // save current form selection to local memory
 function saveSelection() {

--- a/app/components/ResultsTableFilter.vue
+++ b/app/components/ResultsTableFilter.vue
@@ -50,7 +50,7 @@
         :name="search?.name"
         placeholder="Search..."
         :value="filterState.fieldsState.value[search.filterField]"
-        class="w-full rounded-full border border-granite bg-transparent p-1 pl-8 outline-none transition-colors focus:w-full focus:min-w-40 focus:bg-fog dark:focus:bg-basalt"
+        class="form-input w-full rounded-full border border-granite p-1 pl-8 outline-none transition-colors focus:w-full focus:min-w-40"
         @input="
           filterState.updateField(
             search?.filterField,
@@ -64,11 +64,11 @@
     <div
       v-for="field in selectFields"
       :key="field.name"
-      class="grid columns-1 justify-center border-b border-red"
+      class="grid columns-1 justify-center"
       :class="{ 'hidden sm:grid': field.isLeastPriority }"
     >
       <label
-        class="font-serif text-xs"
+        class="form-label text-xs"
         :for="field.name"
       >
         {{ field.name }}
@@ -78,7 +78,7 @@
         :id="field.name"
         :key="field.name"
         :name="field.name"
-        class="cursor-pointer bg-transparent fill-red text-left"
+        class="form-select text-left"
         :value="filterState.fieldsState.value[field.filterField]"
         @input="
           filterState.updateField(

--- a/app/components/SearchBar.vue
+++ b/app/components/SearchBar.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 /**
- * SearchBar.vue - UI for interacting with Open5e search. Allows users to type 
- * a search query. When the SearchBar is activated the user is redirected to 
+ * SearchBar.vue - UI for interacting with Open5e search. Allows users to type
+ * a search query. When the SearchBar is activated the user is redirected to
  * the `/search` page with the query param populated with their query text
  *
  * -= EMITS =-
@@ -25,11 +25,11 @@
     </button>
 
     <!-- Source Selector Button -->
-    <button 
+    <button
       class="group absolute right-10 top-1 flex items-center text-granite hover:text-black dark:hover:text-white"
       @click="showSourcesModal = true"
     >
-      <Icon name="ion:options" class="z-40 size-8 rounded-full bg-transparent p-1" />
+      <Icon name="ion:options" class="z-40 size-8 rounded-full p-1" />
       <span class="absolute right-0 top-7 z-10 hidden text-nowrap rounded-full border border-black bg-white px-4 py-[0.1rem] text-xs font-bold uppercase text-black group-hover:block dark:z-30 dark:border-white dark:bg-black dark:text-white">
         {{ `Edit sources (${sources.length})` }}
       </span>
@@ -37,8 +37,8 @@
 
     <input
       v-model="query"
-      class="z-10 w-full rounded-full border border-granite p-2 pl-4 shadow placeholder:text-sm placeholder:text-granite focus:bg-fog focus:outline-none dark:bg-darkness dark:focus:bg-charcoal"
-      placeholder="Search Sources..." 
+      class="form-input z-10 w-full rounded-full border border-granite bg-transparent p-2 pl-4 shadow placeholder:text-sm placeholder:text-granite focus:bg-fog focus:outline-none dark:bg-darkness dark:focus:bg-charcoal"
+      placeholder="Search Sources..."
       @keyup.enter="doSearch(query)"
     />
 

--- a/app/components/TabBar.vue
+++ b/app/components/TabBar.vue
@@ -1,0 +1,62 @@
+<template>
+  <div
+    role="tablist"
+    class="flex gap-1 border-b border-granite"
+  >
+    <button
+      v-for="tab in tabs"
+      :id="`tab-${tab.id}`"
+      :key="tab.id"
+      type="button"
+      role="tab"
+      :aria-selected="model === tab.id"
+      :aria-controls="`tabpanel-${tab.id}`"
+      :tabindex="model === tab.id ? 0 : -1"
+      class="cursor-pointer px-4 py-2 text-left transition-colors"
+      :class="model === tab.id
+        ? 'border-b-2 border-red text-blood dark:text-fireball'
+        : 'text-black dark:text-white hover:text-red/50 dark:hover:text-red/50'"
+
+      @click="model = tab.id"
+      @keydown="onKeydown($event, tab.id)"
+    >
+      <span class="block">{{ tab.label }}</span>
+      <span
+        v-if="tab.subtitle"
+        class="block text-xs text-granite"
+      >
+        {{ tab.subtitle }}
+      </span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { TabBarItem } from '@/types';
+
+const props = defineProps<{
+  tabs: TabBarItem[];
+}>();
+
+const model = defineModel<string>({ required: true });
+
+function onKeydown(event: KeyboardEvent, tabId: string) {
+  const ids = props.tabs.map(tab => tab.id);
+  const currentIndex = ids.indexOf(tabId);
+  if (currentIndex === -1) return;
+
+  let nextIndex = currentIndex;
+
+  if (event.key === 'ArrowRight') {
+    nextIndex = (currentIndex + 1) % ids.length;
+  } else if (event.key === 'ArrowLeft') {
+    nextIndex = (currentIndex - 1 + ids.length) % ids.length;
+  } else {
+    return;
+  }
+
+  event.preventDefault();
+  model.value = ids[nextIndex]!;
+  document.getElementById(`tab-${ids[nextIndex]}`)?.focus();
+}
+</script>

--- a/app/components/ToolButton.vue
+++ b/app/components/ToolButton.vue
@@ -6,7 +6,7 @@
     >
       <slot />
     </button>
-    <div class="absolute right-8 top-0 z-10 hidden h-10 justify-center overflow-hidden text-nowrap bg-red px-4 align-middle text-sm font-bold uppercase transition-all group-hover:grid">
+    <div class="absolute right-6 top-0 z-10 hidden h-10 justify-center overflow-hidden text-nowrap bg-red px-4 align-middle text-sm font-bold uppercase transition-all group-hover:grid">
       <span class="mr-4 mt-[0.6rem] inline-block text-center align-middle text-white">{{ title }}</span>
       <span class="absolute -right-5 size-10 rounded-full bg-white dark:bg-darkness"/>
     </div>

--- a/app/components/ToolButtonSourceSelector.vue
+++ b/app/components/ToolButtonSourceSelector.vue
@@ -5,10 +5,10 @@
     :title="`Select Sources`"
   >
   <div class="flex flex-col items-center justify-center">
-    <Icon name="majesticons:book-open-line" class="z-20 -my-1 size-6"/>
+    <Icon name="majesticons:book-open-line" class="z-20 size-6"/>
     <p
       v-if="selectedSourcesFraction"
-      class="z-30 my-0 text-nowrap py-0 text-xs text-black  dark:text-white"
+      class="transpar absolute -bottom-3 z-30 mb-0 text-nowrap rounded-full border border-black bg-white px-2 text-xs text-black dark:border-white dark:bg-black dark:text-white"
     >
       {{ selectedSourcesFraction }}
     </p>

--- a/app/components/ToolButtonSourceSelector.vue
+++ b/app/components/ToolButtonSourceSelector.vue
@@ -4,15 +4,16 @@
     :on-click-handler="() => showModal = true"
     :title="`Select Sources`"
   >
-    <Icon name="majesticons:book-open-line" class="z-20 size-6"/>
+  <div class="flex flex-col items-center justify-center">
+    <Icon name="majesticons:book-open-line" class="z-20 -my-1 size-6"/>
     <p
-      v-if="selectedSourcesFraction" 
-      class="absolute -bottom-3 z-30 my-0 text-nowrap py-0 text-xs text-black  dark:text-white"
+      v-if="selectedSourcesFraction"
+      class="z-30 my-0 text-nowrap py-0 text-xs text-black  dark:text-white"
     >
       {{ selectedSourcesFraction }}
     </p>
-
-    <ModalSourceSelector 
+  </div>
+    <ModalSourceSelector
       :show="showModal"
       @close="showModal = false"
     />

--- a/app/helpers/resultsTableConfig/monsters.ts
+++ b/app/helpers/resultsTableConfig/monsters.ts
@@ -73,7 +73,7 @@ export const monsterFilterSelectFieldsDefinition: ResultTableSelectFieldFilter[]
     isLeastPriority: true,
   },
   {
-    name: 'CR (min)',
+    name: 'CR min',
     filterField: 'challenge_rating__gte',
     options: monsterChallengeRatings.map(([name, value]) => ({
       name: name,
@@ -81,7 +81,7 @@ export const monsterFilterSelectFieldsDefinition: ResultTableSelectFieldFilter[]
     })),
   },
   {
-    name: 'CR (max)',
+    name: 'CR max',
     filterField: 'challenge_rating__lte',
     options: monsterChallengeRatings.map(([name, value]) => ({
       name: name,

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -14,8 +14,8 @@
       </aside>
 
       <!-- Page central column -->
-      <div 
-        class="w-screen flex-1 overflow-hidden bg-white pl-2 text-charcoal transition-transform dark:bg-darkness dark:text-white sm:p-0 sm:transition-none"
+      <div
+        class="w-screen flex-1 overflow-hidden bg-white text-charcoal transition-transform dark:bg-darkness dark:text-white sm:p-0 sm:transition-none"
         :class="isNavbarVisible ? 'translate-x-56 sm:translate-x-0' : ''"
       >
         <div class="content-wrapper h-full overflow-y-auto  overflow-x-hidden">
@@ -33,8 +33,8 @@
 
             <ToolBarToggle class="my-2 mr-4 flex-none" @btn-clicked="toggleToolbar" />
           </header>
-          
-          <div class="mt-2 grid h-min w-full justify-center gap-1 px-2 text-lg sm:m-4 sm:justify-start sm:pl-4">
+
+          <div class="mb-0 mt-2 grid h-min w-full justify-center gap-1 pb-0 text-lg sm:m-4 sm:mb-0 sm:justify-start sm:pl-4">
             <BreadcrumbLinks class="grow" />
           </div>
 
@@ -56,7 +56,7 @@
           v-if="!isEncounterVisible"
           @encounter-builder-clicked="toggleEncounter"
         />
-        <div 
+        <div
           v-else
           class="h-min border-granite sm:border-l"
         >
@@ -64,7 +64,7 @@
         </div>
       </div>
     </div>
-    
+
     <AppFooter />
 
     <!-- Shade: fades out main content when sidebar expanded on mobile -->

--- a/app/pages/backgrounds/index.vue
+++ b/app/pages/backgrounds/index.vue
@@ -2,17 +2,6 @@
   <section class="w-screen sm:w-full">
     <div class="flex">
       <h1 class="my-2">Backgrounds</h1>
-
-      <ResultsTablePaginator
-        :page-number="paginator.pageNo || 1"
-        :last-page-number="paginator.lastPageNo || 1"
-        :items-per-page="paginator.itemsPerPage || 1"
-        :total-items="data?.count || 1"
-        @first="paginator.firstPage()"
-        @next="paginator.nextPage()"
-        @prev="paginator.prevPage()"
-        @last="paginator.lastPage()"
-      />
     </div>
 
     <ResultsTableFilter
@@ -30,6 +19,16 @@
       :is-sort-descending="isSortDescending"
       @sort="(sortValue) => setSortState(sortValue)"
     />
+    <ResultsTablePaginator
+        :page-number="paginator.pageNo || 1"
+        :last-page-number="paginator.lastPageNo || 1"
+        :items-per-page="paginator.itemsPerPage || 1"
+        :total-items="data?.count || 1"
+        @first="paginator.firstPage()"
+        @next="paginator.nextPage()"
+        @prev="paginator.prevPage()"
+        @last="paginator.lastPage()"
+      />
   </section>
 </template>
 

--- a/app/pages/classes/index.vue
+++ b/app/pages/classes/index.vue
@@ -1,19 +1,7 @@
 <template>
   <section class="docs-container container">
-    <div class="grid w-full grid-cols-2">
+    <div class="flex w-full">
       <h1 class="my-2 w-screen">Classes</h1>
-      
-      <ResultsTablePaginator
-        class="w-min-content w-full"
-        :page-number="paginator.pageNo || 1"
-        :last-page-number="paginator.lastPageNo || 1"
-        :items-per-page="paginator.itemsPerPage || 1"
-        :total-items="data?.count || 1"
-        @first="paginator.firstPage()"
-        @next="paginator.nextPage()"
-        @prev="paginator.prevPage()"
-        @last="paginator.lastPage()"
-      />
     </div>
 
     <ResultsTableFilter
@@ -31,6 +19,16 @@
       :sort-by="sortBy"
       @sort="(sortValue) => setSortState(sortValue)"
     />
+    <ResultsTablePaginator
+        :page-number="paginator.pageNo || 1"
+        :last-page-number="paginator.lastPageNo || 1"
+        :items-per-page="paginator.itemsPerPage || 1"
+        :total-items="data?.count || 1"
+        @first="paginator.firstPage()"
+        @next="paginator.nextPage()"
+        @prev="paginator.prevPage()"
+        @last="paginator.lastPage()"
+      />
   </section>
 </template>
 

--- a/app/pages/conditions/index.vue
+++ b/app/pages/conditions/index.vue
@@ -2,17 +2,6 @@
   <section class="w-screen sm:w-full">
     <div class="flex">
       <h1 class="my-2">Conditions</h1>
-
-      <ResultsTablePaginator
-        :page-number="paginator.pageNo || 1"
-        :last-page-number="paginator.lastPageNo || 1"
-        :items-per-page="paginator.itemsPerPage || 1"
-        :total-items="data?.count || 1"
-        @first="paginator.firstPage()"
-        @next="paginator.nextPage()"
-        @prev="paginator.prevPage()"
-        @last="paginator.lastPage()"
-      />
     </div>
 
     <ResultsTableFilter
@@ -30,6 +19,16 @@
       :is-sort-descending="isSortDescending"
       @sort="(sortValue) => setSortState(sortValue)"
     />
+    <ResultsTablePaginator
+        :page-number="paginator.pageNo || 1"
+        :last-page-number="paginator.lastPageNo || 1"
+        :items-per-page="paginator.itemsPerPage || 1"
+        :total-items="data?.count || 1"
+        @first="paginator.firstPage()"
+        @next="paginator.nextPage()"
+        @prev="paginator.prevPage()"
+        @last="paginator.lastPage()"
+      />
   </section>
 </template>
 

--- a/app/pages/equipment/index.vue
+++ b/app/pages/equipment/index.vue
@@ -4,17 +4,6 @@
       <h1 class="my-2">
         Equipment
       </h1>
-
-      <ResultsTablePaginator
-        :page-number="paginator.pageNo || 1"
-        :last-page-number="paginator.lastPageNo || 1"
-        :items-per-page="paginator.itemsPerPage || 1"
-        :total-items="data?.count || 1"
-        @first="paginator.firstPage()"
-        @next="paginator.nextPage()"
-        @prev="paginator.prevPage()"
-        @last="paginator.lastPage()"
-      />
     </div>
 
     <ResultsTableFilter
@@ -33,6 +22,16 @@
       :is-sort-descending="isSortDescending"
       @sort="(sortValue) => setSortState(sortValue)"
     />
+    <ResultsTablePaginator
+        :page-number="paginator.pageNo || 1"
+        :last-page-number="paginator.lastPageNo || 1"
+        :items-per-page="paginator.itemsPerPage || 1"
+        :total-items="data?.count || 1"
+        @first="paginator.firstPage()"
+        @next="paginator.nextPage()"
+        @prev="paginator.prevPage()"
+        @last="paginator.lastPage()"
+      />
   </section>
 </template>
 

--- a/app/pages/feats/index.vue
+++ b/app/pages/feats/index.vue
@@ -2,17 +2,6 @@
   <section class="w-screen sm:w-full">
     <div class="flex">
       <h1 class="my-2">Feats</h1>
-
-      <ResultsTablePaginator
-        :page-number="paginator.pageNo || 1"
-        :last-page-number="paginator.lastPageNo || 1"
-        :items-per-page="paginator.itemsPerPage || 1"
-        :total-items="data?.count || 1"
-        @first="paginator.firstPage()"
-        @next="paginator.nextPage()"
-        @prev="paginator.prevPage()"
-        @last="paginator.lastPage()"
-      />
     </div>
 
     <ResultsTableFilter
@@ -30,6 +19,16 @@
       :is-sort-descending="isSortDescending"
       @sort="(sortValue) => setSortState(sortValue)"
     />
+    <ResultsTablePaginator
+        :page-number="paginator.pageNo || 1"
+        :last-page-number="paginator.lastPageNo || 1"
+        :items-per-page="paginator.itemsPerPage || 1"
+        :total-items="data?.count || 1"
+        @first="paginator.firstPage()"
+        @next="paginator.nextPage()"
+        @prev="paginator.prevPage()"
+        @last="paginator.lastPage()"
+      />
   </section>
 </template>
 

--- a/app/pages/magic-items/index.vue
+++ b/app/pages/magic-items/index.vue
@@ -1,20 +1,9 @@
 <template>
   <section class="docs-container container">
-    <div class="flex justify-between">
+    <div class="flex w-full">
       <h1 class="my-2 w-full">
         Magic Items
       </h1>
-
-      <ResultsTablePaginator
-        :page-number="paginator.pageNo || 1"
-        :last-page-number="paginator.lastPageNo || 1"
-        :items-per-page="paginator.itemsPerPage || 1"
-        :total-items="data?.count || 1"
-        @first="paginator.firstPage()"
-        @next="paginator.nextPage()"
-        @prev="paginator.prevPage()"
-        @last="paginator.lastPage()"
-      />
     </div>
 
     <ResultsTableFilter
@@ -34,6 +23,16 @@
       :is-sort-descending="isSortDescending"
       @sort="(sortValue) => setSortState(sortValue)"
     />
+    <ResultsTablePaginator
+        :page-number="paginator.pageNo || 1"
+        :last-page-number="paginator.lastPageNo || 1"
+        :items-per-page="paginator.itemsPerPage || 1"
+        :total-items="data?.count || 1"
+        @first="paginator.firstPage()"
+        @next="paginator.nextPage()"
+        @prev="paginator.prevPage()"
+        @last="paginator.lastPage()"
+      />
   </section>
 </template>
 

--- a/app/pages/monsters/index.vue
+++ b/app/pages/monsters/index.vue
@@ -5,16 +5,6 @@
         Monsters
       </h1>
 
-      <ResultsTablePaginator
-        :page-number="paginator.pageNo || 1"
-        :last-page-number="paginator.lastPageNo || 1"
-        :items-per-page="paginator.itemsPerPage || 1"
-        :total-items="data?.count || 1"
-        @first="paginator.firstPage()"
-        @next="paginator.nextPage()"
-        @prev="paginator.prevPage()"
-        @last="paginator.lastPage()"
-      />
     </div>
 
     <ResultsTableFilter
@@ -39,6 +29,16 @@
         </div>
       </template>
     </ResultsTable>
+    <ResultsTablePaginator
+        :page-number="paginator.pageNo || 1"
+        :last-page-number="paginator.lastPageNo || 1"
+        :items-per-page="paginator.itemsPerPage || 1"
+        :total-items="data?.count || 1"
+        @first="paginator.firstPage()"
+        @next="paginator.nextPage()"
+        @prev="paginator.prevPage()"
+        @last="paginator.lastPage()"
+      />
   </section>
 </template>
 

--- a/app/pages/rules/index.vue
+++ b/app/pages/rules/index.vue
@@ -2,17 +2,6 @@
   <section class="w-screen sm:w-full">
     <div class="flex">
       <h1 class="my-2">Rules</h1>
-
-      <ResultsTablePaginator
-        :page-number="paginator.pageNo || 1"
-        :last-page-number="paginator.lastPageNo || 1"
-        :items-per-page="paginator.itemsPerPage || 1"
-        :total-items="data?.count || 1"
-        @first="paginator.firstPage()"
-        @next="paginator.nextPage()"
-        @prev="paginator.prevPage()"
-        @last="paginator.lastPage()"
-      />
     </div>
 
     <ResultsTableFilter
@@ -30,6 +19,16 @@
       :is-sort-descending="isSortDescending"
       @sort="(sortValue) => setSortState(sortValue)"
     />
+    <ResultsTablePaginator
+        :page-number="paginator.pageNo || 1"
+        :last-page-number="paginator.lastPageNo || 1"
+        :items-per-page="paginator.itemsPerPage || 1"
+        :total-items="data?.count || 1"
+        @first="paginator.firstPage()"
+        @next="paginator.nextPage()"
+        @prev="paginator.prevPage()"
+        @last="paginator.lastPage()"
+      />
   </section>
 </template>
 

--- a/app/pages/species/index.vue
+++ b/app/pages/species/index.vue
@@ -2,17 +2,6 @@
   <section class="w-screen sm:w-full">
     <div class="flex">
       <h1 class="my-2">Species</h1>
-
-      <ResultsTablePaginator
-        :page-number="paginator.pageNo || 1"
-        :last-page-number="paginator.lastPageNo || 1"
-        :items-per-page="paginator.itemsPerPage || 1"
-        :total-items="data?.count || 1"
-        @first="paginator.firstPage()"
-        @next="paginator.nextPage()"
-        @prev="paginator.prevPage()"
-        @last="paginator.lastPage()"
-      />
     </div>
 
     <ResultsTableFilter
@@ -30,6 +19,16 @@
       :is-sort-descending="isSortDescending"
       @sort="(sortValue) => setSortState(sortValue)"
     />
+    <ResultsTablePaginator
+        :page-number="paginator.pageNo || 1"
+        :last-page-number="paginator.lastPageNo || 1"
+        :items-per-page="paginator.itemsPerPage || 1"
+        :total-items="data?.count || 1"
+        @first="paginator.firstPage()"
+        @next="paginator.nextPage()"
+        @prev="paginator.prevPage()"
+        @last="paginator.lastPage()"
+      />
   </section>
 </template>
 

--- a/app/pages/spells/index.vue
+++ b/app/pages/spells/index.vue
@@ -4,17 +4,6 @@
       <h1 class="my-2 w-screen sm:w-full">
         Spells
       </h1>
-
-      <ResultsTablePaginator
-        :page-number="paginator.pageNo || 1"
-        :last-page-number="paginator.lastPageNo || 1"
-        :items-per-page="paginator.itemsPerPage || 1"
-        :total-items="data?.count || 1"
-        @first="paginator.firstPage()"
-        @next="paginator.nextPage()"
-        @prev="paginator.prevPage()"
-        @last="paginator.lastPage()"
-      />
     </div>
 
     <ResultsTableFilter
@@ -34,6 +23,16 @@
       :is-sort-descending="isSortDescending"
       @sort="(sortValue) => setSortState(sortValue)"
     />
+    <ResultsTablePaginator
+        :page-number="paginator.pageNo || 1"
+        :last-page-number="paginator.lastPageNo || 1"
+        :items-per-page="paginator.itemsPerPage || 1"
+        :total-items="data?.count || 1"
+        @first="paginator.firstPage()"
+        @next="paginator.nextPage()"
+        @prev="paginator.prevPage()"
+        @last="paginator.lastPage()"
+      />
   </section>
 </template>
 

--- a/app/styles/forms.css
+++ b/app/styles/forms.css
@@ -1,0 +1,28 @@
+@layer components {
+
+  .form-label {
+    @apply font-serif whitespace-nowrap;
+  }
+
+  .form-input,
+  .form-select {
+    @apply
+    rounded-md
+    px-1
+    outline-none border border-transparent focus:border focus:border-red
+    bg-black/10 dark:bg-white/10 focus:bg-fog dark:focus:bg-basalt;
+  }
+
+  .form-select {
+    @apply cursor-pointer appearance-none;
+  }
+
+  label+.form-input,
+  label+.form-select {
+    @apply mt-1;
+  }
+
+  .form-select {
+    @apply cursor-pointer appearance-none;
+  }
+}

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -1,5 +1,6 @@
 @import './base.css';
 @import './typography.css';
+@import './forms.css';
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
## Description

Visual styling on toolbar buttons to avoid black ovals, reduced breadcrumb prominence and space used, adjusted select and text inputs to ensure they are consistent and recognizable as inputs

Moved pagination buttons to bottom of lists (this improves UX, since users typically need the next page after reviewing the list and not finding their obejective)

Before
<img width="1483" height="324" alt="image" src="https://github.com/user-attachments/assets/3dd2b898-2592-4a34-adf3-3915b88737e3" />

After
<img width="1480" height="242" alt="image" src="https://github.com/user-attachments/assets/324cc472-5613-4d42-8ab4-7f2078ee82cf" />

--------

Before
<img width="613" height="254" alt="image" src="https://github.com/user-attachments/assets/2268b730-856d-4ac4-8f18-3fd0dfb83ae8" />

After
<img width="578" height="378" alt="image" src="https://github.com/user-attachments/assets/1ebec3ae-cf37-4055-82d6-e32fcd222613" />

## How was this tested?

Tested in local

*[Link to a staging deploy](#) page if your item can only be seen on certain pages.*

