### PR TITLE
[BUGFIX] Fixed bugs in `/tests/units/pages` test cases

### DIFF
--- a/tests/unit/pages/background.test.tsx
+++ b/tests/unit/pages/background.test.tsx
@@ -1,20 +1,8 @@
 import { test, expect } from 'vitest';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
-import ConditionPage from '~/pages/feats/[id].vue';
+import FeatPage from '~/pages/feats/[id].vue';
 
 const { data: background } = useFindOne(API_ENDPOINTS.backgrounds, 'srd_acolyte');
-
-const page = await mountSuspended(ConditionPage);
-
-test('/backgrounds/[id] page can mount', async () => {
-  expect(page);
-});
-
-test('/backgrounds/[id] page renders title', async () => {
-  const title = page.find('h1');
-  expect(title.exists()).toBe(true);
-  expect(title.text()).toEqual(unref(background)?.name);
-});
 
 mockNuxtImport('useFindOne', () => {
   return () => ({
@@ -57,3 +45,16 @@ mockNuxtImport('useFindOne', () => {
     },
   });
 });
+
+test('/backgrounds/[id] page can mount', async () => {
+  const page = await mountSuspended(FeatPage);
+  expect(page);
+});
+
+test('/backgrounds/[id] page renders title', async () => {
+  const page = await mountSuspended(FeatPage);
+  const title = page.find('h1');
+  expect(title.exists()).toBe(true);
+  expect(title.text()).toEqual(unref(background)?.name);
+});
+

--- a/tests/unit/pages/backgrounds.test.tsx
+++ b/tests/unit/pages/backgrounds.test.tsx
@@ -2,9 +2,9 @@ import { test, expect } from 'vitest';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
 import FeatsPage from '~/pages/feats/index.vue';
 
-const page = await mountSuspended(FeatsPage);
 
 test('/backgrounds page can mount', async () => {
+  const page = await mountSuspended(FeatsPage);
   expect(page);
 });
 

--- a/tests/unit/pages/classes.test.tsx
+++ b/tests/unit/pages/classes.test.tsx
@@ -2,9 +2,9 @@ import { test, expect } from 'vitest';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
 import ClassesPage from '~/pages/classes/index.vue';
 
-const page = await mountSuspended(ClassesPage);
 
 test('/classes page can mount', async () => {
+  const page = await mountSuspended(ClassesPage);
   expect(page);
 });
 

--- a/tests/unit/pages/conditions.test.tsx
+++ b/tests/unit/pages/conditions.test.tsx
@@ -2,9 +2,9 @@ import { test, expect } from 'vitest';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
 import ConditionsPage from '~/pages/conditions/index.vue';
 
-const page = await mountSuspended(ConditionsPage);
 
 test('/conditions page can mount', async () => {
+  const page = await mountSuspended(ConditionsPage);
   expect(page);
 });
 

--- a/tests/unit/pages/feat.test.tsx
+++ b/tests/unit/pages/feat.test.tsx
@@ -1,16 +1,16 @@
 import { test, expect } from 'vitest';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
-import ConditionPage from '~/pages/feats/[id].vue';
+import FeatPage from '~/pages/feats/[id].vue';
 
 const { data: feat } = useFindOne(API_ENDPOINTS.feats, 'srd_grappler');
 
-const page = await mountSuspended(ConditionPage);
-
 test('/feats/[id] page can mount', async () => {
+  const page = await mountSuspended(FeatPage);
   expect(page);
 });
 
 test('/feats/[id] page renders title', async () => {
+  const page = await mountSuspended(FeatPage);
   const title = page.find('h1');
   expect(title.exists()).toBe(true);
   expect(title.text()).toEqual(unref(feat)?.name);

--- a/tests/unit/pages/feats.test.tsx
+++ b/tests/unit/pages/feats.test.tsx
@@ -2,9 +2,9 @@ import { test, expect } from 'vitest';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
 import FeatsPage from '~/pages/feats/index.vue';
 
-const page = await mountSuspended(FeatsPage);
 
 test('/feats page can mount', async () => {
+  const page = await mountSuspended(FeatsPage);
   expect(page);
 });
 

--- a/tests/unit/pages/magic-item.test.tsx
+++ b/tests/unit/pages/magic-item.test.tsx
@@ -7,13 +7,13 @@ const { data: item } = useFindOne(
   'srd_adamantine-armor-breastplate',
 );
 
-const page = await mountSuspended(MagicItemPage);
-
 test('/magic-items/[id] page can mount', async () => {
+  const page = await mountSuspended(MagicItemPage);
   expect(page);
 });
 
 test('/magic-items/[id] page renders title', async () => {
+  const page = await mountSuspended(MagicItemPage);
   const title = page.find('h1');
   expect(title.exists()).toBe(true);
   expect(title.text()).toEqual(unref(item)?.name);

--- a/tests/unit/pages/magic-items.test.tsx
+++ b/tests/unit/pages/magic-items.test.tsx
@@ -2,9 +2,9 @@ import { test, expect } from 'vitest';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
 import MagicItemsPage from '~/pages/magic-items/index.vue';
 
-const page = await mountSuspended(MagicItemsPage);
 
 test('/magic-items page can mount', async () => {
+  const page = await mountSuspended(MagicItemsPage);
   expect(page);
 });
 

--- a/tests/unit/pages/monster.test.tsx
+++ b/tests/unit/pages/monster.test.tsx
@@ -4,13 +4,13 @@ import MonsterPage from '~/pages/monsters/[id].vue';
 
 const { data: monster } = useFindOne(API_ENDPOINTS.monsters, 'srd_goblin');
 
-const page = await mountSuspended(MonsterPage);
-
 test('/monsters/[id] page can mount', async () => {
+  const page = await mountSuspended(MonsterPage);
   expect(page);
 });
 
 test('/monsters/[id] page renders title', async () => {
+  const page = await mountSuspended(MonsterPage);
   const title = page.find('h1');
   expect(title.exists()).toBe(true);
   expect(title.text()).toEqual(unref(monster)?.name);

--- a/tests/unit/pages/monsters.test.tsx
+++ b/tests/unit/pages/monsters.test.tsx
@@ -2,9 +2,8 @@ import { test, expect } from 'vitest';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
 import MonstersPage from '~/pages/monsters/index.vue';
 
-const page = await mountSuspended(MonstersPage);
-
 test('/monsters page can mount', async () => {
+  const page = await mountSuspended(MonstersPage);
   expect(page);
 });
 

--- a/tests/unit/pages/species-plural.test.tsx
+++ b/tests/unit/pages/species-plural.test.tsx
@@ -2,9 +2,8 @@ import { test, expect } from 'vitest';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
 import SpeciesPage from '~/pages/species/index.vue';
 
-const page = await mountSuspended(SpeciesPage);
-
 test('/species page can mount', async () => {
+  const page = await mountSuspended(SpeciesPage);
   expect(page);
 });
 

--- a/tests/unit/pages/species.test.tsx
+++ b/tests/unit/pages/species.test.tsx
@@ -4,13 +4,13 @@ import SpeciesPage from '~/pages/species/[id].vue';
 
 const { data: species } = useFindOne(API_ENDPOINTS.species, 'srd_elf');
 
-const page = await mountSuspended(SpeciesPage);
-
 test('/species/[id] page can mount', async () => {
+  const page = await mountSuspended(SpeciesPage);
   expect(page);
 });
 
 test('/species/[id] page renders title', async () => {
+  const page = await mountSuspended(SpeciesPage);
   const title = page.find('h1');
   expect(title.exists()).toBe(true);
   expect(title.text()).toEqual(unref(species)?.name);

--- a/tests/unit/pages/spell.test.tsx
+++ b/tests/unit/pages/spell.test.tsx
@@ -7,13 +7,13 @@ const { data: spell } = useFindOne(
   'srd_magic-missile',
 );
 
-const page = await mountSuspended(SpellPage);
-
 test('/magic-items/[id] page can mount', async () => {
+  const page = await mountSuspended(SpellPage);
   expect(page);
 });
 
 test('/magic-items/[id] page renders title', async () => {
+  const page = await mountSuspended(SpellPage);
   const title = page.find('h1');
   expect(title.exists()).toBe(true);
   expect(title.text()).toEqual(unref(spell)?.name);

--- a/tests/unit/pages/spells.test.tsx
+++ b/tests/unit/pages/spells.test.tsx
@@ -2,9 +2,8 @@ import { test, expect } from 'vitest';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
 import SpellsPage from '~/pages/spells/index.vue';
 
-const page = await mountSuspended(SpellsPage);
-
 test('/spells page can mount', async () => {
+  const page = await mountSuspended(SpellsPage);
   expect(page);
 });
 


### PR DESCRIPTION
## Description

This PR fixes an issue where errors in some of our tests were causing tests to fail on a PR that patched a vulnerability in `vitest` (PR #924).

The solution to the problem was the calls to `mountSuspended()` occurring outside the testing functions and this triggering some kind of scope/key error.

Merging these changes into the development branch for PR #924, all tests are now passing where previously 14 were failing.

## Related Issue

Closes #925 

## How was this tested?

On local I merged this branch into #924 and `npm run test`, all tests were green.